### PR TITLE
Additional changes for Dev Docs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -8,10 +8,3 @@ metaDataFormat: "yaml"
 pygmentsCodeFences: true
 pygmentsCodeFencesGuessSyntax: true
 pygmentsStyle: github
-
-menu:
-  topnav:
-  - name: "code"
-    weight: -110
-    identifier: "code"
-    url: "https://github.com/syndesisio"

--- a/content/community/engineering_guidelines.md
+++ b/content/community/engineering_guidelines.md
@@ -30,10 +30,6 @@ As an alternative to or extension of the [guideline above]({{< relref "#discuss-
 
 Features normally span more than one component. Having relevant people assigned to an issue from the start will hopefully gain more complete ownership from beginning to end. As an example, for a feature that adds new pages to the UI, it is expected that UX, UI, backend, QE, and docs would all be involved. Let's call these "feature miniteams". Miniteams are adhoc teams and people can be expected to be a member of multiple miniteams at one time.
 
-## Commit messages should follow the Conventional Commits standardized commit message format
-
-This allows for automated changelog generation. Recommended tooling includes [Commitizen](https://github.com/commitizen/cz-cli) to make get the format correct rather than hand crafting. Commits should be linted in future in CI but aren't just yet... coming soon! See [Conventional Commits](http://conventionalcommits.org/) for details on the commit format.
-
 ## Every pull request must be linked to an issue
 
 This allows discussion on the particular feature or bug in the issue before necessarily any coding takes place. This does not mean that there should only be one pull request for an issue.

--- a/content/community/engineering_guidelines.md
+++ b/content/community/engineering_guidelines.md
@@ -50,7 +50,7 @@ However, it should taken care that the PR review process does not take too long 
 
 * A PR which is marked as 'done' (i.e. not marked as 'work-in-progress') should be merged or rejected with 3 business days.
 * There should be at most 2 review turnarounds (i.e. reviewer requests changes - author makes changes - reviewer request final changes - author makes changes - reviewer accepts / rejects). This is **not** a hard rule, more a reminder to keep PR reviews focused.
-* If after 2 turnarounds there are outstanding review issues but the overall functionality is ok and the CI checks are succesful, it should be considered to merge the PR and to create new GitHub issues for these extra review comments.
+* If after 2 turnarounds there are outstanding review issues but the overall functionality is ok and the CI checks are successful, it should be considered to merge the PR and to create new GitHub issues for these extra review comments.
 * Discuss only the content of the PR in the review, don't drift away and discuss issues not directly related with the PR. Instead open a new issue for anything which is discovered aside.
 * A reviewer should be actively selected by the author immediately after creating the PR, e.g. asking on IRC or mailing list.
 

--- a/content/community/engineering_guidelines.md
+++ b/content/community/engineering_guidelines.md
@@ -30,6 +30,10 @@ As an alternative to or extension of the [guideline above]({{< relref "#discuss-
 
 Features normally span more than one component. Having relevant people assigned to an issue from the start will hopefully gain more complete ownership from beginning to end. As an example, for a feature that adds new pages to the UI, it is expected that UX, UI, backend, QE, and docs would all be involved. Let's call these "feature miniteams". Miniteams are adhoc teams and people can be expected to be a member of multiple miniteams at one time.
 
+## Commit messages should follow the Conventional Commits standardized commit message format
+
+This allows for automated changelog generation. Recommended tooling includes [Commitizen](https://github.com/commitizen/cz-cli) to make get the format correct rather than hand crafting. Commits should be linted in future in CI but aren't just yet... coming soon! See [Conventional Commits](http://conventionalcommits.org/) for details on the commit format.
+
 ## Every pull request must be linked to an issue
 
 This allows discussion on the particular feature or bug in the issue before necessarily any coding takes place. This does not mean that there should only be one pull request for an issue.

--- a/content/docs.md
+++ b/content/docs.md
@@ -18,19 +18,5 @@ menu:
 This handbook contain all information required for installing, running and developing Syndesis from a developer's point of view.
 
 <div class="alert alert-info admonition" role="alert">
-  <i class="fa fa-exclamation-circle important"></i> Please use the links in the sidebar on the left to navigate the Developer Docs.
-</div>
-
-
-<div class="alert alert-info admonition" role="alert">
   <i class="fa fa-exclamation-circle note"></i> Please use the links in the sidebar on the left to navigate the Developer Docs.
-</div>
-
-
-<div class="alert alert-info admonition" role="alert">
-  <i class="fa fa-exclamation-circle caution"></i> Please use the links in the sidebar on the left to navigate the Developer Docs.
-</div>
-
-<div class="alert alert-info admonition" role="alert">
-  <i class="fa fa-exclamation-circle warning"></i> Please use the links in the sidebar on the left to navigate the Developer Docs.
 </div>

--- a/content/docs.md
+++ b/content/docs.md
@@ -17,4 +17,6 @@ menu:
 
 This handbook contain all information required for installing, running and developing Syndesis from a developer's point of view.
 
-Please use the links in the sidebar on the left to navigate the Developer Docs.
+<div class="alert alert-info" role="alert">
+  <strong>NOTE:</strong> Please use the links in the sidebar on the left to navigate the Developer Docs.
+</div>

--- a/content/docs.md
+++ b/content/docs.md
@@ -18,5 +18,5 @@ menu:
 This handbook contain all information required for installing, running and developing Syndesis from a developer's point of view.
 
 <div class="alert alert-info admonition" role="alert">
-  <i class="fa fa-exclamation-circle note"></i> Please use the links in the sidebar on the left to navigate the Developer Docs.
+  <i class="fa note"></i> Please use the links in the sidebar on the left to navigate the Developer Docs.
 </div>

--- a/content/docs.md
+++ b/content/docs.md
@@ -17,6 +17,20 @@ menu:
 
 This handbook contain all information required for installing, running and developing Syndesis from a developer's point of view.
 
-<div class="alert alert-info" role="alert">
-  <strong>NOTE:</strong> Please use the links in the sidebar on the left to navigate the Developer Docs.
+<div class="alert alert-info admonition" role="alert">
+  <i class="fa fa-exclamation-circle important"></i> Please use the links in the sidebar on the left to navigate the Developer Docs.
+</div>
+
+
+<div class="alert alert-info admonition" role="alert">
+  <i class="fa fa-exclamation-circle note"></i> Please use the links in the sidebar on the left to navigate the Developer Docs.
+</div>
+
+
+<div class="alert alert-info admonition" role="alert">
+  <i class="fa fa-exclamation-circle caution"></i> Please use the links in the sidebar on the left to navigate the Developer Docs.
+</div>
+
+<div class="alert alert-info admonition" role="alert">
+  <i class="fa fa-exclamation-circle warning"></i> Please use the links in the sidebar on the left to navigate the Developer Docs.
 </div>

--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -430,6 +430,10 @@ currently connected OpenShift project.
 If you want to use a different project, then use `--project` (short:
 `-p`) to specify this project.
 
+<div class="alert alert-info admonition" role="alert">
+  <i class="fa warning"></i> Any existing project will be deleted first when specified with `--project`. This option is also an easy and quick way to recreate a Syndesis installation.
+</div>
+
 > **Warning**
 > 
 > Any existing project will be deleted first when specified with

--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -372,15 +372,9 @@ syndesis build --clean --camel-snapshot 2.21.0-SNAPSHOT
 
 ## syndesis ui
 
-"syndesis ui" is not implemented yet
-****
-This is just a placeholder, still in the planning phased.
-Nevertheless we already start to document the feature for an "UX first" approach.
-****
-
-### Usage
-
----
+<div class="alert alert-info admonition" role="alert">
+  <i class="fa note"></i> "syndesis ui" is not implemented yet.
+</div>
 
 ## syndesis minishift
 
@@ -1102,11 +1096,9 @@ option. By default, you are asked whether you want to delete the project
 for recreation. You can switch off the security question with the option
 `--yes` (short: `-y`).
 
-> **Warning**
-> 
-> Don’t use `syndesis install --project $(oc project -q) --yes`. You’ll
-> shoot yourself into the foot. Ask the author if you want to know more
-> details.
+<div class="alert alert-info admonition" role="alert">
+  <i class="fa warning"></i> Don’t use `syndesis install --project $(oc project -q) --yes`. You’ll shoot yourself into the foot. Ask the author if you want to know more details.
+</div>
 
 If you want to wait until everything is running (including fetching of
 the Docker images), you can specify `--watch` (short: `-w`) which blocks
@@ -1153,10 +1145,9 @@ installed on this cluster.
 
 ### Quick Installation
 
-> **Warning**
-> 
-> The following scripts are not yet updated and probably don’t work as
-> expected. Please stay tuned.
+<div class="alert alert-info admonition" role="alert">
+  <i class="fa warning"></i> The following scripts are not yet updated and probably don’t work as expected. Please stay tuned.
+</div>
 
 If you only want to install Syndesis without developing for, there is
 even an easier without checking out Syndesis into a local Git

--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -448,7 +448,7 @@ VM does not exist so that you can use `--reset` also on a fresh
 Minishift installation.
 
 If you want to get a real clean installation use `--full-reset` which
-deletes the `~/.minishift` directory which holds downloaded artefacts
+deletes the `~/.minishift` directory which holds downloaded artifacts
 like the ISO image for the Minishift VM. Using `--full-reset` forces
 Minishift to re-download all those files.
 
@@ -595,7 +595,7 @@ supported:
 Use `syndesis release` for performing a release of Syndesis. A Syndesis
 release consists of:
 
-  - Maven artefacts of the backend and runtime services
+  - Maven artifacts of the backend and runtime services
 
   - Docker images pushed to Docker Hub
 
@@ -605,7 +605,7 @@ This chapter describes how you can efficiently perform a release and how
 to troubleshoot if something goes wrong. This documentation might also
 be interesting to you even when you do not perform a release on your
 own, as it might help you to understand how the various Syndesis
-artefacts fit together.
+artifacts fit together.
 
 ### Usage
 
@@ -619,10 +619,10 @@ artefacts fit together.
     
     Options for release:
     -n  --dry-run                 Dry run, which performs the whole build but does no tagging,
-                                  artefact upload or pushing Docker images
+                                  artifact upload or pushing Docker images
         --release-version <ver>   Version to release (e.g. "1.2.1"). This is a mandatory argument.
         --snapshot-release        Snapshot release which can be created on a daily basis.
-                                  A timestamped version will be created automatically, and no Maven artefacts
+                                  A timestamped version will be created automatically, and no Maven artifacts
                                   are pushed to maven central. No moving tag will be moved, too.
         --dev-version <version>   Next development version. If not given, set to
                                   "<major>.<minor>-SNAPSHOT" as calculated from
@@ -673,7 +673,7 @@ look like:
   - Redirect the full output to `/tmp/build.log` but still print the
     main steps to the console.
 
-  - Make only a dry run, without pushing any artefacts out nor checking
+  - Make only a dry run, without pushing any artifacts out nor checking
     in any changed files.
 
 ### Preparations
@@ -681,7 +681,7 @@ look like:
 To perform a release, certain preconditions need to be given.
 
 First of all, you need to have access to the various systems to which
-release artefacts are uploaded:
+release artifacts are uploaded:
 
   - You need to be logged in to [Docker Hub](https://hub.docker.com/)
     and your account needs to have write access to the
@@ -689,12 +689,12 @@ release artefacts are uploaded:
     organisation.
 
   - You have `gpg` to have installed and set up a gpg-agent for being
-    able to sign Maven artefacts during deployment in a non-interactive
+    able to sign Maven artifacts during deployment in a non-interactive
     mode.
 
   - You need to have access to the "syndesis" account on
     ([oss.sonatype.org](http://oss.sonatype.org/\)) for being able to
-    publish Maven artefacts. This credential needs to be added to either
+    publish Maven artifacts. This credential needs to be added to either
     your `~/.m2/settings.xml` or you can use an settings file with the
     `--settings-xml` option. The credential needs to be added to the
     server with the id `oss-sonatype-staging`.
@@ -743,7 +743,7 @@ A release consist of several different steps, which can be grouped into
 two groups:
 
   - **Build steps** are performed to build the release and create the
-    artefacts. Also during the build Maven artefacts are uploaded to the
+    artifacts. Also during the build Maven artifacts are uploaded to the
     staging area for publishing to Maven central
 
   - **Persist steps** are then used for releasing objects, pushing
@@ -767,9 +767,9 @@ two groups:
     streams included in these templates refer to Docker images with the
     new version.
 
-  - Now run an `mvn -Prelease clean deploy` to deploy all artefacts to a
+  - Now run an `mvn -Prelease clean deploy` to deploy all artifacts to a
     new staging repository on oss.sonatype.org, the platform for release
-    artefacts on Maven central. The staging repository on this Sonatype
+    artifacts on Maven central. The staging repository on this Sonatype
     Nexus is validated and closed.
 
   - If `--docker-user` and `--docker-password` is given, then a `docker
@@ -803,7 +803,7 @@ and also *deleted* after the release run.
     version.
 
   - The staging repository on Sonatype is released. It will take a bit,
-    but the artefact should then be downloadable from [Maven
+    but the artifact should then be downloadable from [Maven
     central](https://search.maven.org/) soon after.
 
   - Commit all modified local files to the local Git repo.
@@ -895,7 +895,7 @@ minishift`.
 
 In detail, a snapshot release differs from a normal release as it:
 
-  - …​ doesn’t release artefacts on Maven central, but pushes Docker
+  - …​ doesn’t release artifacts on Maven central, but pushes Docker
     images and creates a Git tag for referencing the proper templates.
 
   - …​ skips all checks and tests when building to maximise the

--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -434,12 +434,6 @@ If you want to use a different project, then use `--project` (short:
   <i class="fa warning"></i> Any existing project will be deleted first when specified with `--project`. This option is also an easy and quick way to recreate a Syndesis installation.
 </div>
 
-> **Warning**
-> 
-> Any existing project will be deleted first when specified with
-> `--project`. This option is also an easy and quick way to recreate a
-> Syndesis installation.
-
 ### Resetting Minishift
 
 The quickest way to get a fresh Syndesis setup is to use `--project`

--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -75,8 +75,8 @@ With this in place, a `--rebase` performs the following steps:
 ### Development Modes
 
 The Syndesis application consists of a set of Docker images OpenShift resources descriptors for installing Syndesis.
-For development, https://www.openshift.org/minishift/[minishift] is used, and most of the commands assume that you have minishift installed locally and executable directly from your path.
-Minishift can be downloaded and installed from https://github.com/minishift/minishift/releases
+For development, [minishift](https://www.openshift.org/minishift/) is used, and most of the commands assume that you have minishift installed locally and executable directly from your path.
+Minishift can be downloaded and installed from https://github.com/minishift/minishift/releases.
 
 For development OpenShift S2I builds and image streams are used.
 This mode works also when running with a real OpenShift cluster and is not restricted to Minishift usage.
@@ -178,7 +178,7 @@ functionality for common developer workflows.
 
 A plain `build` command without any options performs a plain `mvn
 install` for all Java and UI modules. Plus it also builds the
-infrastructure operator via Go (see [syndesis-build-operator](#below)
+infrastructure operator via Go (see [syndesis-build-operator](#infrastructure-operator)
 for details)
 
 This compiles all Java and Javascript artifacts and also runs all tests
@@ -453,7 +453,7 @@ VM:
 | `--cpus`              | Number of CPUs used for the Minishift VM.                                                                        | 2       |
 | `--disk-size`         | Disk space used for Minishift.                                                                                   | 20 GB   |
 | `--show-logs`         | Whether to show OpenShift logs during startup.                                                                   | false   |
-| `--vm-driver`         | Which virtual machine driver to use. For OS X this can be 'virtualbox', 'xhyve' or 'vmwarefusion' (if insalled). |         |
+| `--vm-driver`         | Which virtual machine driver to use. For OS X this can be 'virtualbox', 'xhyve' or 'vmwarefusion' (if installed). |         |
 | `--openshift-version` | OpenShift version to use                                                                                         | 3.7.1   |
 
 ### Example
@@ -650,11 +650,11 @@ An example run for a dry run for `1.3.1` release on the current branch
 look like:
 
 ``` bash
-./tools/bin/syndesis release            1
-    --release-version 1.3.1             2
-    --local-maven-repo /tmp/clean-repo  3
-    --log /tmp/build.log                4
-    --dry-run                           5
+./tools/bin/syndesis release \           1
+    --release-version 1.3.1 \            2
+    --local-maven-repo /tmp/clean-repo \ 3
+    --log /tmp/build.log \               4
+    --dry-run                            5
 ```
 
   1. Always run `syndesis` from the repo and branch you want to release.
@@ -687,7 +687,7 @@ release artifacts are uploaded:
     mode.
 
   - You need to have access to the "syndesis" account on
-    ([oss.sonatype.org](http://oss.sonatype.org/\)) for being able to
+    ([oss.sonatype.org](https://oss.sonatype.org/) for being able to
     publish Maven artifacts. This credential needs to be added to either
     your `~/.m2/settings.xml` or you can use an settings file with the
     `--settings-xml` option. The credential needs to be added to the
@@ -1149,16 +1149,11 @@ installed on this cluster.
   <i class="fa warning"></i> The following scripts are not yet updated and probably don’t work as expected. Please stay tuned.
 </div>
 
-If you only want to install Syndesis without developing for, there is
-even an easier without checking out Syndesis into a local Git
-repository.
+If you only want to install Syndesis without developing for, there is even an easier without checking out Syndesis into a local Git repository.
 
-You can directly use the standalone installation script
-[syndesis-install](https://raw.githubusercontent.com/syndesisio/syndesis/master/tools/bin/install-syndesis)
-for installing Syndesis. Just download this
-[script](https://raw.githubusercontent.com/syndesisio/syndesis/master/tools/bin/install-syndesis),
-save it as "syndesis-install" and then call it
-with
+You can directly use the standalone installation script [syndesis-install](https://raw.githubusercontent.com/syndesisio/syndesis/master/tools/bin/install-syndesis)
+for installing Syndesis. Just download this [script](https://raw.githubusercontent.com/syndesisio/syndesis/master/tools/bin/install-syndesis),
+save it as "syndesis-install" and then call it with
 
 ``` bash
 bash install-syndesis --route $(oc project -q).6a63.fuse-ignite.openshiftapps.com --open
@@ -1166,8 +1161,7 @@ bash install-syndesis --route $(oc project -q).6a63.fuse-ignite.openshiftapps.co
 
 Or, if you feel fancy (and trust us), then you can directly install the
 latest version of Syndesis by deleting and recreating the current
-project with a single
-line:
+project with a single line:
 
 ``` bash
 bash <(curl -sL https://bit.ly/syndesis-install) -p $(oc project -q) -r $(oc project -q).6a63.fuse-ignite.openshiftapps.com -o
@@ -1176,5 +1170,4 @@ bash <(curl -sL https://bit.ly/syndesis-install) -p $(oc project -q) -r $(oc pro
 All you need is to have `bash`, `curl` and `oc` installed and you need
 to be connected to an OpenShift cluster.
 
-Use `install-syndesis --help` for a list of options (which is a subset
-of `syndesis install` described above)
+Use `install-syndesis --help` for a list of options (which is a subset of `syndesis install` described above).

--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -510,7 +510,9 @@ Options for system-test:
 
 ### How it works
 
-NOTE: This section needs a more detailed explanation how the systems tests are working in detail.
+<div class="alert alert-info admonition" role="alert">
+  <i class="fa note"></i> This section needs a more detailed explanation how the systems tests are working in detail.
+</div>
 
 
 
@@ -654,24 +656,24 @@ An example run for a dry run for `1.3.1` release on the current branch
 look like:
 
 ``` bash
-./tools/bin/syndesis release           \ 
-    --release-version 1.3.1            \ 
-    --local-maven-repo /tmp/clean-repo \ 
-    --log /tmp/build.log               \ 
-    --dry-run                            
+./tools/bin/syndesis release            1
+    --release-version 1.3.1             2
+    --local-maven-repo /tmp/clean-repo  3
+    --log /tmp/build.log                4
+    --dry-run                           5
 ```
 
-  - Always run `syndesis` from the repo and branch you want to release.
+  1. Always run `syndesis` from the repo and branch you want to release.
 
-  - The release version is mandatory and must be in the format
+  2. The release version is mandatory and must be in the format
     `<major>.<minor>.<patch>`.
 
-  - Use a clean local Maven repository to avoid side effects
+  3. Use a clean local Maven repository to avoid side effects
 
-  - Redirect the full output to `/tmp/build.log` but still print the
+  4. Redirect the full output to `/tmp/build.log` but still print the
     main steps to the console.
 
-  - Make only a dry run, without pushing any artifacts out nor checking
+  5. Make only a dry run, without pushing any artifacts out nor checking
     in any changed files.
 
 ### Preparations
@@ -830,11 +832,11 @@ remote repository. You can omit this with the option `--no-git-push`. If
 to so, the last step can also be performed manually afterwards with:
 
 ``` bash
-git push 1.2.8
-git push -f 1.2 
+git push 1.2.8   
+git push -f 1.2   1
 ```
 
-  - Using `-f` as the minor tag needs to be moved.
+  1. Using `-f` as the minor tag needs to be moved.
 
 Please be careful to **not** push the master branch upstream (i.e. do
 **not** a plain `git push`). We only want to have the tag with all the
@@ -909,20 +911,20 @@ In detail, a snapshot release differs from a normal release as it:
 
 ``` bash
 syndesis release \
-     --snapshot-release \                   
-     --local-maven-repo /tmp/clean-repo \   
-     --git-remote origin \                  
-     --docker-user "${DOCKER_USER}" \       
+     --snapshot-release \                   1
+     --local-maven-repo /tmp/clean-repo \   2
+     --git-remote origin \                  3
+     --docker-user "${DOCKER_USER}" \       4
      --docker-password "${DOCKER_PASSWORD}"
 ```
 
-  - Enable snapshot release with a version in the format 1.3.5-20180419
+  1. Enable snapshot release with a version in the format 1.3.5-20180419
 
-  - Point to an empty repository to avoid side effects when building
+  2. Point to an empty repository to avoid side effects when building
 
-  - Push to the origin repository
+  3. Push to the origin repository
 
-  - Docker credentials required for pushing to Docker Hub
+  4. Docker credentials required for pushing to Docker Hub
 
 A daily Jenkins job with this configuration run on
 <https://ci.fabric8.io> for creating a daily snapshots.

--- a/content/docs/development.md
+++ b/content/docs/development.md
@@ -32,6 +32,8 @@ groups:
 | **test**        | `io.syndesis.test`        |                            | System tests for testing the whole applications                 |
 
 ![Figure 1. Group dependencies](/images/syndesis-group-dependencies.png)
+
+
 _Figure 1. Group dependencies_
 
 ### Naming Conventions
@@ -218,7 +220,7 @@ replacement.
 ## Source
 
 Labels starting with `source/` indicate the origin of an issue. It
-should be applied to help in triaging and priotizing.
+should be applied to help in triaging and prioritizing.
 
 | Notification  | Description                      |
 | ------------- | -------------------------------- |

--- a/content/docs/development.md
+++ b/content/docs/development.md
@@ -31,9 +31,7 @@ groups:
 | **extension**   | `io.syndesis.extension`   |                            | Library and API for developing Syndesis extensions              |
 | **test**        | `io.syndesis.test`        |                            | System tests for testing the whole applications                 |
 
-**Group dependencies.**
-
-![](images/syndesis-group-dependencies.png)
+![](/images/syndesis-group-dependencies.png)
 
 ### Naming Conventions
 

--- a/content/docs/development.md
+++ b/content/docs/development.md
@@ -31,7 +31,8 @@ groups:
 | **extension**   | `io.syndesis.extension`   |                            | Library and API for developing Syndesis extensions              |
 | **test**        | `io.syndesis.test`        |                            | System tests for testing the whole applications                 |
 
-![](/images/syndesis-group-dependencies.png)
+![Figure 1. Group dependencies](/images/syndesis-group-dependencies.png)
+_Figure 1. Group dependencies_
 
 ### Naming Conventions
 

--- a/content/docs/development.md
+++ b/content/docs/development.md
@@ -41,10 +41,9 @@ _Figure 1. Group dependencies_
 The following conventions are used for naming directories, modules and
 Java packages.
 
-> **Important**
-> 
-> These conventions are mandatory and should be also checked for when
-> doing pull request reviews.
+<div class="alert alert-info admonition" role="alert">
+  <i class="fa important"></i> These conventions are mandatory and should be also checked for when doing pull request reviews.
+</div>
 
   - Each directory directly below `app/` is specific for a certain Maven
     group. E.g. the directory `app/extension` is reserved for all Maven
@@ -76,25 +75,20 @@ Java packages.
     `io.syndesis.common.util` This top-level package should reflect the
     artefact name, with dashes replaced by dots.
 
-> **Note**
-> 
-> Not every module has been already transformed to this scheme. This
-> will happen step-by-step. But for new groups and modules this scheme
-> has to be followed.
 
+
+<div class="alert alert-info admonition" role="alert">
+  <i class="fa note"></i> Not every module has been already transformed to this scheme. This will happen step-by-step. But for new groups and modules this scheme has to be followed.
+</div>
 
 ## Issue Labels
 
 We use GitHub labels to categorize epics, issues and tasks. They are the
 foundation of our process, so please use labels for issues.
 
-> **Caution**
-> 
-> Labels are living entities. This document describes the current status
-> and might be slightly outdated. Please send a PR to adopt this section
-> if the label structure changes. Also feel free to discuss the label
-> structure anytime. It’s essential that labels describe our process,
-> not that we have to adapt our process for these labels.
+<div class="alert alert-info admonition" role="alert">
+  <i class="fa caution"></i> Labels are living entities. This document describes the current status and might be slightly outdated. Please send a PR to adopt this section if the label structure changes. Also feel free to discuss the label structure anytime. It’s essential that labels describe our process, not that we have to adapt our process for these labels.
+</div>
 
 Labels are grouped. Each label consists of two parts: A **Group** and a
 **Name** which are separated by a slash (`/`). For example, the label

--- a/content/quickstart.md
+++ b/content/quickstart.md
@@ -21,10 +21,6 @@ You can try out Syndesis very easily locally, too.
 All you need is a [Minishift](https://www.openshift.org/minishift/) installation which is available for all the  major operating systems (Linux, OS X and Windows).
 The following examples assume that you have Minishift installed and can be called with `minishift` from the command line. So, `minishift` is supposed to be available in your search path, i.e. located in a directory contained in your `$PATH` environment variable (Linux, macOS) or in a directory from your system path (Windows).
 
-
-TIP: Once you've gotten everything set up, you can, we have provided you with a few QuickStarts here.
-
-
 ## Rocket launch
 
 To make the installation super easy, on macOS and Linux you can use the following command for a complete installation of Syndesis on Minishift in the namespace `syndesis`, which will be created on the fly if it does not exist:

--- a/content/quickstart.md
+++ b/content/quickstart.md
@@ -19,7 +19,10 @@ weight: 20
 
 You can try out Syndesis very easily locally, too.
 All you need is a [Minishift](https://www.openshift.org/minishift/) installation which is available for all the  major operating systems (Linux, OS X and Windows).
-The following examples assume that you have Minishift installed and can be called with `minishift` from the command line. So, `minishift` is supposed to be available in your search path, i.e. located in a directory contained in your `$PATH` environment variable (Linux, macOS) or in a directory from your system path (Windows)
+The following examples assume that you have Minishift installed and can be called with `minishift` from the command line. So, `minishift` is supposed to be available in your search path, i.e. located in a directory contained in your `$PATH` environment variable (Linux, macOS) or in a directory from your system path (Windows).
+
+
+TIP: Once you've gotten everything set up, you can, we have provided you with a few QuickStarts here.
 
 
 ## Rocket launch

--- a/themes/syndesis/layouts/partials/github-corner.html
+++ b/themes/syndesis/layouts/partials/github-corner.html
@@ -1,4 +1,4 @@
-<a href="https://github.com/syndesisio" class="github-corner hidden-md-down" aria-label="View source on Github">
+<a href="https://github.com/syndesisio" class="github-corner hidden-md-down" aria-label="View source on Github" rel="nofollow" target="_blank">
   <svg width="74" height="74" viewBox="0 0 250 250" style="fill:#fff;z-index:2000;color:#0088ce;mix-blend-mode:screen;position:absolute;top:0;border:0;right:0" aria-hidden="true">
     <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
     <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7

--- a/themes/syndesis/scss/_asciidoc.scss
+++ b/themes/syndesis/scss/_asciidoc.scss
@@ -1,0 +1,90 @@
+/***
+Temporary workarounds for switching from Asciidoc to Markdown.
+***/
+
+// Alternating colors for table rows
+
+#main {
+    table {
+    display: table;
+    border-collapse: collapse;
+    border-color: grey;
+    border-spacing: 2px;
+    empty-cells: hide;
+    line-height: 1.5;
+    margin-bottom: 1.5rem;
+    overflow: auto;
+    width: 100%;
+
+    thead {
+      display: table-header-group;
+      vertical-align: middle;
+      border-color: inherit;
+
+      th,
+      tr {
+        :empty {
+          display: none;
+        }
+      }
+    }
+
+    tbody {
+      display: table-row-group;
+      vertical-align: middle;
+      border-color: inherit;
+    }
+
+    th {
+      font-weight: 600;
+    }
+
+    tr {
+      background-color: #fff;
+      border-top: 1px solid #c6cbd1;
+      display: table-row;
+    }
+
+    tr:nth-child(2n) {
+      background-color: #f6f8fa;
+    }
+
+    td,
+    th {
+      border: 1px solid #dfe2e5;
+      padding: 6px 13px;
+    }
+  }
+}
+
+/** Admonition
+This is by no means really an admonition--it's just a Bootstrap alert
+with Font Awesome, made to look a little bit more like an admonition in the meantime.
+**/
+.admonition {
+  .fa {
+    font-size: x-large;
+    padding-right: 0.75em;
+    vertical-align: bottom;
+  }
+
+  .caution:before {
+    content: "\f06d";
+    color: #bf3400;
+  }
+
+  .important:before {
+    content: "\f06a";
+    color: #bf0000;
+  }
+
+  .note:before {
+    content: "\f05a";
+    color: #19407c;
+  }
+
+  .warning:before {
+    content: "\f071";
+    color: #bf6900;
+  }
+}

--- a/themes/syndesis/scss/_asciidoc.scss
+++ b/themes/syndesis/scss/_asciidoc.scss
@@ -58,7 +58,7 @@ Temporary workarounds for switching from Asciidoc to Markdown.
 }
 
 /** Admonition
-This is by no means really an admonition--it's just a Bootstrap alert
+This is by NO means really an admonition--it's just a Bootstrap alert
 with Font Awesome, made to look a little bit more like an admonition in the meantime.
 **/
 .admonition {

--- a/themes/syndesis/scss/_asciidoc.scss
+++ b/themes/syndesis/scss/_asciidoc.scss
@@ -62,10 +62,13 @@ This is by NO means really an admonition--it's just a Bootstrap alert
 with Font Awesome, made to look a little bit more like an admonition in the meantime.
 **/
 .admonition {
+  display: table;
+  
   .fa {
+    display: table-cell;
     font-size: x-large;
     padding-right: 0.75em;
-    vertical-align: bottom;
+    vertical-align: middle;
   }
 
   .caution:before {

--- a/themes/syndesis/scss/_footer.scss
+++ b/themes/syndesis/scss/_footer.scss
@@ -6,12 +6,13 @@
 
 .page-footer {
   background-color: $pf-black;
+  bottom: 0;
   color: $pf-white;
+  height: 20rem;
+  margin-top: 8em;
   padding-top: 2rem;
   padding-bottom: 2rem;
-  height: 20rem;
   position: absolute;
-  bottom: 0;
   width: 100%;
 
   .row {

--- a/themes/syndesis/scss/_sidenav.scss
+++ b/themes/syndesis/scss/_sidenav.scss
@@ -7,6 +7,7 @@
 .sidenav {
   color: $brand-primary;
   background-color: #eee;
+  height: 100%;
   margin-top: -26px;
   margin-left: 0;
   border-right: 1px solid #d7d7d7;

--- a/themes/syndesis/scss/syndesis.scss
+++ b/themes/syndesis/scss/syndesis.scss
@@ -26,14 +26,13 @@ body {
 }
 
 #main {
-  padding-bottom: 20rem;
+    padding-bottom: 25rem;
 
   @include media-breakpoint-down(sm) {
     padding-bottom: 32rem;
   }
 
   .main-content {
-    margin-bottom: 8em;
     padding-left: 15px;
     padding-right: 15px;
     width: 100%;

--- a/themes/syndesis/scss/syndesis.scss
+++ b/themes/syndesis/scss/syndesis.scss
@@ -1,6 +1,7 @@
 @import "./bootstrap/_variables";
 @import "../../../node_modules/bootstrap/scss/bootstrap";
 
+@import "asciidoc";
 @import "blog";
 @import "colors";
 @import "docs";
@@ -58,59 +59,6 @@ body {
 
     pre {
       background: #f7f7f8 !important;
-    }
-  }
-
-  table {
-    //display: block;
-    display: table;
-    border-collapse: collapse;
-    //border-collapse: separate;
-    border-color: grey;
-    border-spacing: 2px;
-    empty-cells: hide;
-    line-height: 1.5;
-    margin-bottom: 1.5rem;
-    overflow: auto;
-    width: 100%;
-
-    thead {
-      display: table-header-group;
-      vertical-align: middle;
-      border-color: inherit;
-
-      th,
-      tr {
-        :empty {
-          display: none;
-        }
-      }
-    }
-
-    tbody {
-      display: table-row-group;
-      vertical-align: middle;
-      border-color: inherit;
-    }
-
-    th {
-      font-weight: 600;
-    }
-
-    tr {
-      background-color: #fff;
-      border-top: 1px solid #c6cbd1;
-      display: table-row;
-    }
-
-    tr:nth-child(2n) {
-      background-color: #f6f8fa;
-    }
-
-    td,
-    th {
-      border: 1px solid #dfe2e5;
-      padding: 6px 13px;
     }
   }
 }

--- a/themes/syndesis/scss/syndesis.scss
+++ b/themes/syndesis/scss/syndesis.scss
@@ -33,6 +33,7 @@ body {
   }
 
   .main-content {
+    margin-bottom: 8em;
     padding-left: 15px;
     padding-right: 15px;
     width: 100%;

--- a/themes/syndesis/theme.toml
+++ b/themes/syndesis/theme.toml
@@ -12,12 +12,6 @@ min_version = "0.20.6"
   homepage = "https://syndesis.io/"
 
 [[docs.sidenav]]
-    name = "code"
-    weight = -110
-    identifier = "code"
-    url = "https://github.com/syndesisio"
-
-[[docs.sidenav]]
     name = "faq"
     weight = -120
     identifier = "faq"


### PR DESCRIPTION
Some changes:
- Temporary admonition, code block workaround for Markdown, add asciidoc SCSS file for now.
- Remove "Code" from top navigation bar, as this is already linked to from the Octocat at the top, and the footer.
- Octocat `rel="nofollow"` for SEO, open in new tab
- Several typo fixes, broken links, internal relative links not working, CSS/padding fixes

Would like to resolve the issue with the table cell background colors, but this may be a futile effort if we are intending to do major changes to the website in the near future (e.g. switch framework or formatting tool). Also a low priority.

<img width="1680" alt="screenshot 2018-11-20 15 22 17" src="https://user-images.githubusercontent.com/3844502/48788840-95d07c80-ece3-11e8-9e84-9d55b85f0bdc.png">

<img width="1680" alt="screenshot 2018-11-20 15 23 13" src="https://user-images.githubusercontent.com/3844502/48788853-9a953080-ece3-11e8-9ce4-cde550468f39.png">
