### PR TITLE
Fix invisible logo on firefox

### DIFF
--- a/themes/syndesis/layouts/partials/topnav.html
+++ b/themes/syndesis/layouts/partials/topnav.html
@@ -2,7 +2,7 @@
   <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#top-nav" aria-controls="top-nav" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <a href="{{ .Site.BaseURL }}" title="{{ .Site.Title }}">
+  <a href="{{ .Site.BaseURL }}" title="{{ .Site.Title }}" class="logo-wrapper">
     <img src="/images/syndesis_logo_full_darkbkg.svg" alt="{{ .Site.Title }} Logo" height="80%" width="75%">
   </a>
   <div class="collapse navbar-collapse" id="top-nav">

--- a/themes/syndesis/scss/_navbar.scss
+++ b/themes/syndesis/scss/_navbar.scss
@@ -22,5 +22,8 @@ nav.navbar {
       border-bottom: 1px solid $pf-white;
     }
   }
+  
+  .logo-wrapper {
+    min-width: 230px;
+  }
 }
-


### PR DESCRIPTION
Here is a little fix to show the logo on Firefox, without an explicit width for the container (or for the logo itself) firefox use the space for the navigation menu on the right