### PR TITLE
Fixed a typo of syndesis install example

### DIFF
--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -1065,7 +1065,7 @@ minishift start --memory 4192
 oc login -u system:admin
 
 # Register CRD and grant permissions to "developer"
-syndesis --setup --grant developer --cluster
+syndesis install --setup --grant developer --cluster
 
 # Switch to account developer
 oc login -u developer


### PR DESCRIPTION
We need to use the "syndesis install" to  Register CRD and grant permissions.