### PR TITLE
chore: bind Hugo server to 0.0.0.0

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,7 +51,7 @@ gulp.task('watch', gulp.parallel(gulp.series('fonts', 'fonts:watch'), gulp.serie
 gulp.task('hugo:serve', function (cb) {
   var exec = require('child_process').exec;
 
-  exec('hugo serve', function (err, stdout, stderr) {
+  exec('hugo serve --bind 0.0.0.0', function (err, stdout, stderr) {
     console.log(stdout);
     console.log(stderr);
     cb(err);


### PR DESCRIPTION
By default Hugo would bind to `localhost`/`127.0.0.1`, when developing
the website inside the container and exposing the `1313` port this
becomes a problem as a port bound to `localhost` can't be exposed.

This adds the `--bind 0.0.0.0` so that Hugo's server binds to all
interfaces/ip addresses available. This allows the port to be exposed
when running within a container.