### PR TITLE
chore: update docs

### DIFF
--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -13,16 +13,30 @@ weight: 10
 
 ## Buildtool "syndesis"
 
-Syndesis uses a single tool for controlling various aspects of the build and developer related tasks.
-This script can be found in `$SYNDESIS_DIR/tools/bin` and is called `syndesis`.
-It requires bash and can be used on any Unix or macOS.
+Syndesis uses a single tool for controlling various aspects of the build
+and developer related tasks.  This script can be found in
+`$SYNDESIS_DIR/tools/bin` and is called `syndesis`.  It requires bash
+and can be used on any Unix or macOS.
 
-To have this script handy all the time it is recommended to either put this `bin/` directory into the path or add a symlink from `syndesis` into a directory which is already on your execution path.
+To have this script handy all the time it is recommended to either put
+this `bin/` directory into the path or add a symlink from `syndesis`
+into a directory which is already on your execution path.
 
-The script can be used for various tasks which are selected by a so-called command_ which is the first argument to the script.
+```shell
+# Navigate to syndesis project directory
+$ cd $SYNDESIS_DIR
+
+# Set path to include Syndesis' tool directory
+$ export PATH=${PATH}:$(pwd)/tools/bin
+
+# Alternatively, set a symbolic link to "syndesis"
+$ ln -s $(pwd)/tools/bin/syndesis /usr/local/bin
+```
+
+The script can be used for various tasks which are selected by a
+so-called command_ which is the first argument to the script.
 
 Just type `syndesis -h` to get an overview of the commands available:
-
 
 ### Usage Message
 ```
@@ -30,36 +44,39 @@ Usage: syndesis <command> [... options ...]
 
 with the following commands
 
-   build            Build Syndesis builds
-   completion       Shell completion
-   crc              Initialize and manage a developer environment using OCP4 CodeReady Containers
-   dev              Syndesis developer tools
-   doc              Generate Syndesis Developer Handbook (SDH)
-   install          Install Syndesis to a connected OpenShift cluster
+   build             Build Syndesis
+   completion        Shell completion
+   crc               Initialize and manage a developer environment using OCP4 CodeReady Containers
+   dev               Syndesis developer tools
+   install           Install Syndesis to a connected OpenShift cluster
    integration-test  Run integration tests
-   kamel            Tools for developing integrations using Camel K
-   minishift        Initialize and manage a Minishift developer environment
-   release          Perform a release
-   system-test      Run system tests
-   ui               Syndesis UI tasks
+   kamel             Tools for developing integrations using Camel K
+   minishift         Initialize and manage a Minishift developer environment
+   release           Perform a release
+   system-test       Run system tests
+   ui                Syndesis UI tasks
 
 "build" is the default command if no command is specified.
 ```
 
+Every sub command also offers usage information accessible using
+`syndesis subcommand --help`.
 
 There are a handful of global options which can be used:
 
-||||
-| ------------- |--------| ------|
-| `--help`      | `-h`   | Print usage information. If a command is given print out commands specific options. |
-| `--rebase`    | `-r`   | Rebase your project directory before building to integrate upstream changes to your local repository. See below for details how this works. |
-| `--verbose`   | &nbsp; | Set verbose mode, which is useful mostly only for debugging the script itself. |
-
+|               |        |                                                                                                                                                                    |
+| ------------- |--------| -------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--help`      | `-h`   | Print usage information. If a command is given print out commands specific options.                                                                                |
+| `--rebase`    | `-r`   | Rebase your project directory before building to integrate upstream changes to your local repository. See [below](#rebase-to-upstream) for details how this works. |
+| `--verbose`   | &nbsp; | Set verbose mode, which is useful mostly only for debugging the script itself.                                                                                     |
 
 ### Rebase to Upstream
 
-To easily rebase on changes which have been merged upstream to master, you can use the option `--rebase` (short: `-r`).
-This command assumes that you have forked the Syndesis GitHub repositories and you have "origin" and "upstream" remotes like
+To easily rebase on changes which have been merged upstream to master,
+you can use the option `--rebase` (short: `-r`).
+
+This command assumes that you have forked the Syndesis GitHub
+repositories and you have "origin" and "upstream" remotes like
 
 ```
 $ git remote -v
@@ -69,27 +86,42 @@ upstream  https://github.com/syndesisio/syndesis (fetch)
 upstream  https://github.com/syndesisio/syndesis (push)
 ```
 
-Use the following command to add the upstream syndesis repository: `git remote add upstream git@github.com:syndesisio/syndesis.git`
+Use the following command to add the upstream syndesis repository: `git
+remote add upstream git@github.com:syndesisio/syndesis.git`
 
 With this in place, a `--rebase` performs the following steps:
 
 * Refresh upstream remote: `git fetch upstream master`
-* Try a `git rebase upstream/master` which rebases your current local working branch.
+* Try a `git rebase upstream/master` which rebases your current local
+  working branch.
 * If this fails because you have uncommitted work:
   - A `git stash` is performed
   - The rebase is retried and should succeed
-  - `git stash pop` brings back your changes. Stashing can fail with conflicts which you would have to resolve on your own.
+  - `git stash pop` brings back your changes. Stashing can fail with
+    conflicts which you would have to resolve on your own.
 
 
 ### Development Modes
 
-The Syndesis application consists of a set of Docker images OpenShift resources descriptors for installing Syndesis.
-For development, [minishift](https://www.openshift.org/minishift/) is used, and most of the commands assume that you have minishift installed locally and executable directly from your path.
-Minishift can be downloaded and installed from https://github.com/minishift/minishift/releases.
+The Syndesis application consists of a set of Docker images OpenShift
+resources descriptors for installing Syndesis.
+For development, [minishift](https://www.openshift.org/minishift/) or
+[CodeReady Containers](https://code-ready.github.io/crc/) are used, and
+most of the commands assume that you have either `minishift` or `crc`
+installed locally and executable directly from your path.
+
+Minishift can be downloaded and installed from
+https://github.com/minishift/minishift/releases.
+
+Installation instructions for CodeReady Containers can be found in the
+[project's
+documentation](https://code-ready.github.io/crc/#installation_gsg).
 
 For development OpenShift S2I builds and image streams are used.
-This mode works also when running with a real OpenShift cluster and is not restricted to Minishift usage.
-The advantage is that a build automatically triggers a redeployment, so you don't have to kill any pods manually.
+This mode works also when running with a real OpenShift cluster and is
+not restricted to Minishift or CodeReady Containers usage.
+The advantage is that a build automatically triggers a redeployment, so
+you don't have to restart any pods manually.
 
 
 ### Commands
@@ -98,29 +130,32 @@ All other options are specific to each command.
 You get a list of those options with `syndesis <cmd> -h`.
 These options are described in detail in the next sections.
 
-The following commands are available:
+The following commands are highlighted in this document:
 
-|Command      | Description|
-| ----------- | -----------|
-| build       | Used for building Syndesis and its various modules   |
-| ui          | Start the UI for local development _(not implemented yet)_ |
-| minishift   | Start and install Syndesis on Minishift |
-| install     | Install Syndesis in a running cluster (other than Minishift) |
-| system-test | Run System test against an OpenShift cluster |
-| dev         | Utility commands useful during development |
-| doc         | Generating and publish this documentation |
-| release     | Release Syndesis' Maven and NPM artifacts _(not implemented yet)_ |
+|Command      | Description                                                                          |
+| ----------- | ------------------------------------------------------------------------------------ |
+| build       | Used for building Syndesis and its various modules                                   |
+| ui          | Start the UI for local development                                                   |
+| crc         | Start and install Syndesis on OCP4 CodeReady Containers                              |
+| minishift   | Start and install Syndesis on Minishift                                              |
+| install     | Install Syndesis in a running cluster (other than Minishift or CodeReady Containers) |
+| dev         | Utility commands useful during development                                           |
+| release     | Release Syndesis                                                                     |
 
-If no command is given, `build` is the default.
-Remember a command must be the first argument, but there are additional possibilities to specify commands:
+If no command is given, `build` is the default.  Remember a command must
+be the first argument, but there are additional possibilities to specify
+commands:
 
-* You can use the form `--command` anywhere as an option, too. E.g. using  `--minishift` is the same as specifying "minishift" as the first argument.
-* A `--mode command` can be used, too (e.g. `--mode sytem-test`)
+* You can use the form `--command` anywhere as an option, too. E.g.
+  using  `--minishift` is the same as specifying "minishift" as the
+  first argument.
+* A `--mode command` can be used, too (e.g. `--mode ui`)
 
-The next sections describe the commands in detail.
-To add a new command, just drop a script file into `$SYNDESIS_DIR/tools/bin/commands` directory with following structure:
+The next sections describe the commands in detail.  To add a new
+command, just drop a script file into `$SYNDESIS_DIR/tools/bin/commands`
+directory with following structure:
 
-```
+```shell
 #!/bin/bash
 
 yourscriptname::description() {
@@ -142,52 +177,15 @@ yourscriptname::run() {
 
 The primary goal of `syndesis build` is to build Syndesis.
 
-It is mainly a wrapper around Maven and Go but adds some convenience
-functionality for common developer workflows.
+It is mainly a wrapper around Maven, Yarn and Go but adds some
+convenience functionality for common developer workflows.
 
-### Usage
-
-    Usage: syndesis build [... options ...]
-    
-    Options for build:
-        -b  --backend                  Build only backend modules (core, extension, integration, connectors, server, meta)
-            --all-images               Build all modules with images: ui-react, server, meta, s2i, operator, upgrade
-            --app-images               Build only application modules with Docker images (ui-react, server, meta, s2i)
-                                       and create images
-            --infra-images             Build only infrastructure modules with Docker images (operator, upgrade) and create images
-        -m  --module <m1>,<m2>, ..     Build modules
-                                       Modules: ui-react, server, connector, s2i, meta, integration, extension, common, operator, upgrade
-                                       Submodules: defined with [groupId]:artifactId (e.g. :connector-sql)
-        -d  --dependencies             Build also all project the specified module depends on
-            --skip-tests               Skip unit, integration and system test execution
-            --skip-checks              Disable all checks
-        -f  --flash                    Skip checks and tests execution (fastest mode)
-        -i  --image                    Build Docker via s2i images, too (for those modules creating images)
-            --docker                   Use a plain Docker build for creating images. Used by CI for pushing to Docker Hub
-        -p  --project <project>        Specifies the project / namespace to create images
-        -g  --goals <g1>,<g2>, ..      Use custom Maven goals to execute for the build. Default goal is `install`
-        -s  --settings <path>          Path to Maven settings.xml
-        -l  --local                    If building the operators, use a locally installed go
-                                       Otherwise run the Go build from a container (either local or Minishift's Docker  daemon)
-            --clean-cache              Used for the operator build to remove the local dependency cache.
-        -c  --clean                    Run clean builds (mvn clean)
-            --incremental [ref]        Run an incremental build, i.e. skip building of a module if committed or uncomitted changes
-                                       against [ref] (default master) are not part of that module
-            --resume <m1>              Resume build from maven module (mvn -rf m1)
-            --batch-mode               Run mvn in batch mode
-            --camel-snapshot <version> Run a build with a specific Camel snapshot. The
-                                       environment variable CAMEL_SNAPSHOT_VERSION is used and you need to set it or an error will be thrown.
-            --maven-mirror <url>       Use the maven mirror for the build, e.g. a maven repo proxy in OpenShift. If no
-                                       argument is given, the MAVEN_MIRROR_URL environment variable is used or
-                                       'http://nexus.myproject:8081/nexus/content/groups/public', if none is set.
-                                       See also https://docs.openshift.com/container-platform/3.5/dev_guide/app_tutorials/maven_tutorial.html
-            --man                      Open HTML documentation in the Syndesis Developer Handbook
 ### Modules
 
 A plain `build` command without any options performs a plain `mvn
 install` for all Java and UI modules. Plus it also builds the
-infrastructure operator via Go (see [syndesis-build-operator](#infrastructure-operator)
-for details)
+infrastructure operator via Go (see
+[syndesis-build-operator](#infrastructure-operator) for details)
 
 This compiles all Java and Javascript artifacts and also runs all tests
 and code checks for the application modules.
@@ -199,25 +197,38 @@ application itself.
 
 You can individually select specific modules by using the `--module`
 (short: `-m`) option with a comma-separated list of modules, but there
-are also option to combine modules
+are also option to combine modules.
 
-The following modules are
-available:
+For example to build just the UI you can run:
+
+```shell
+$ syndesis build -m ui
+```
+
+The following modules are available:
 
 | Module          | Description                                                                            | `--all-images` | `--backend` | `--app-images` | `--infra-images` |
 | --------------- | -------------------------------------------------------------------------------------- | -------------- | ----------- | -------------- | ---------------- |
-| **server**      | Main backend providing a REST API for the user interface                               | ✔︎             | ✔︎          | ✔︎             |                  |
-| **ui**          | The SPA user interface application                                                     | ✔︎             |             | ✔︎             |                  |
-| **meta**        | Meta data and verifier used for verifying connections and providing connector metadata | ✔︎             | ✔︎          | ✔︎             |                  |
-| **connector**   | All connectors used by Syndesis out of the box                                         |                | ✔︎          |                |                  |
-| **integration** | Support libraries for running integrations                                             |                | ✔︎          |                |                  |
-| **extension**   | Tools for developing and running Syndesis custom extensions                            |                | ✔︎          |                |                  |
-| **common**      | Common modules containing common code                                                  |                | ✔︎          |                |                  |
-| **s2i**         | S2I base image used for building the runtime images                                    | ✔︎             |             | ✔︎             |                  |
-| **operator**    | Infrastructure operator for managing the application                                   | ✔︎             |             |                | ✔︎               |
+| **server**      | Main backend providing a REST API for the user interface                               | ✔︎              | ✔︎           | ✔︎              |                  |
+| **ui**          | The SPA user interface application                                                     | ✔︎              |             | ✔︎              |                  |
+| **meta**        | Meta data and verifier used for verifying connections and providing connector metadata | ✔︎              | ✔︎           | ✔︎              |                  |
+| **connector**   | All connectors used by Syndesis out of the box                                         |                | ✔︎           |                |                  |
+| **integration** | Support libraries for running integrations                                             |                | ✔︎           |                |                  |
+| **extension**   | Tools for developing and running Syndesis custom extensions                            |                | ✔︎           |                |                  |
+| **common**      | Common modules containing common code                                                  |                | ✔︎           |                |                  |
+| **s2i**         | S2I base image used for building the runtime images                                    | ✔︎              |             | ✔︎              |                  |
+| **operator**    | Infrastructure operator for managing the application                                   | ✔︎              |             |                | ✔︎                |
 
 All option ending with `-images` will also build the corresponding
 Docker image.
+
+In addition to using top level modules that combine to a set of
+submodules you can also specify a very specific submodule using its
+groupId and/or artifactId. For instance the module name for the SQL
+connector module would be `io.syndesis.connector:connector-sql` or
+simply `:connector-sql`. In case you skip the groupId the leading colon
+in the module name is very important because this identifies the module
+to be a submodule rather that a top level module.
 
 When you build individual modules you you can provide the option
 `--image` (short: `-i`) to create also the Docker image in the build,
@@ -256,20 +267,21 @@ images)
 
 ### Maven mirror
 
-At build time the dependencies are downloaded from maven central repository, 
-it is recommended to install a local maven repository manager on your openshift 
-to also serve as repository for the `s2i` builds running in openshift. If you 
-want to have the local maven repository automatically created, you can specify
-the `--maven-mirror` parameter when installing minishift.
+At build time the dependencies are downloaded from maven central
+repository, it is recommended to install a local maven repository
+manager on your openshift to also serve as repository for the `s2i`
+builds running in openshift. If you want to have the local maven
+repository automatically created, you can specify the `--maven-mirror`
+parameter when installing minishift.
 
-To build syndesis modules with the local maven mirror, use the `--maven-mirror`
-parameter, example:
+To build syndesis modules with the local maven mirror, use the
+`--maven-mirror` parameter, example:
 
 ``` shell
-syndesis build -m server -d -i -f --maven-mirror
+$ syndesis build -m server -d -i -f --maven-mirror
 ```
 
-### Infrastructure Operator
+### Syndesis Operator
 
 `syndesis build` can also build the infrastructure operator, which is a
 golang program.
@@ -280,10 +292,8 @@ part of a module collection like `--all-images` or `--infra-images`
 There are three modes, how the operator can be created:
 
   - Running you go compiler locally
-
   - Compiling in a local Docker daemon which allows volume mounts with
     the localhost
-
   - Compiling in Minishift Docker daemon, which was made accessible via
     `eval $(minishift docker-env)`
 
@@ -294,8 +304,7 @@ See below for the details.
 In any case, before you compile first you should use the option
 `--ensure` (short: `-e`) to setup the dependency tree. This will
 download all source dependency and cache them locally. To get rid of
-this cache, use the option `--clean-cache`. This might be necessary when
-`go dep` 's cache gets into a weird state.
+this cache, use the option `--clean-cache`.
 
 If you compile for the first time, then `--ensure` will be added
 automatically.
@@ -312,11 +321,11 @@ either move your project directory to this location or work with a
 symlink:
 
 ``` shell
-cd ~/Development/syndesis
-mkdir -p $GOPATH/src/github.com/syndesisio
-cd ..
-mv syndesis $GOPATH/src/github.com/syndesisio/
-ln -s $GOPATH/src/github.com/syndesisio/ syndesis
+$ cd ~/Development/syndesis
+$ mkdir -p $GOPATH/src/github.com/syndesisio
+$ cd ..
+$ mv syndesis $GOPATH/src/github.com/syndesisio/
+$ ln -s $GOPATH/src/github.com/syndesisio/ syndesis
 ```
 
 By default this compiles into for your native architecture (amd64,
@@ -327,8 +336,8 @@ be used in a Linux image.
 **Compiling with a local Docker daemon**
 
 This is the default mode and is used also when doing the release. It use
-a builder image `syndesis/godev` which is created from the `tools/image`
-directory and fetched from Docker Hub.
+a builder image `operator-builder` which is created from the embedded
+Dockerfile in the `install/operator/.lib.sh` script.
 
 For this mode to work your Docker daemon must support volume mounts to
 the system from where you are calling `syndesis`. This is the case on
@@ -336,39 +345,12 @@ Linux for locally installed Docker daemon and for Mac with *Docker for
 Mac*. It is **not** the case for Minishift which runs in a disconnected
 VM. But see below how you still can use Minishift for building.
 
-`dep ensure` and `go build` will be run from this `syndesis/godev`
-image, but with your local directory mounted into the container so that
-the fetched dependencies can be cached in the local directories
-`dep-cache` and `vendor` so that the can be reused for the next run.
+`go build` with `-mod=vendor` will be run from this an ad-hoc container
+image (`operator-builder`), with your local directory mounted into
+the container so that the fetched dependencies can be cached in the 
+local directories  `vendor` so that the can be reused for the next run.
 Also the binary will be stored in your local directory, but this will
 alway be a Linux (`amd64`) binary.
-
-**Compiling with Minishift**
-
-As Minishift is running in a remote VM you cannot bind a volume to your
-localhost. Therefor when running in Minishift mode the source code will
-be rsynced to a directory in the Minishift VM (`rsync` will be installed
-in the Minishift VM on the first run).
-
-The build with `syndesis/godev` will then be started with a volume mount
-to the copied directory in the VM. After the build the generated binary
-is copied back with `rsync` to your local directory.
-
-The Minishift mode is automatically detected and selected if
-`DOCKER_CERTS` contains a path to `.minishift`. You enable the Minishift
-Docker daemon for your local CLI with `eval $(minishift docker-env)`
-
-Some simple benchmark reveals the following timings (in minutes)
-:
-
-| Context               | Local | Local Docker (macOS) | Minishift Docker |
-| --------------------- | ----- | -------------------- | ---------------- |
-| Cold (no build cache) | 0:40  | 10:09                | 1:36             |
-| Hot (with dep cache)  | 0:08  | 2:47                 | 0:13             |
-
-The fastest mode is obviously the local mode, followed surprisingly by
-Minishift. The local mode is probably slow because of how the macOS
-daemon mounts ts volumes (which can probably be optimized)
 
 ### Examples
 
@@ -376,79 +358,98 @@ Some common usage examples for `syndesis build` are
 
 ``` shell
 # Build all images (app and infrastructure) with S2I
-syndesis build --all-images
+$ syndesis build --all-images
 
 # Create all application images and re-deploy Syndesis in the
 # Openshift cluster, but do it as fast as possible. Don't build
 # any golang code
-syndesis build --app-images --flash
+$ syndesis build --app-images --flash
 
 # Create the infrastructure operator by running go locally
 # and calling dep ensure before
-syndesis build -m operator --local --ensure
+$ syndesis build -m operator --local --ensure
 
 # Use a Camel snapshot for a clean build, build all modules
-syndesis build --clean --camel-snapshot 2.21.0-SNAPSHOT
+$ syndesis build --clean --camel-snapshot 2.21.0-SNAPSHOT
 ```
-
-
 
 ## syndesis ui
 
-<div class="alert alert-info admonition" role="alert">
-  <i class="fa note"></i> "syndesis ui" is not implemented yet.
-</div>
+[Yarn](https://yarnpkg.com) is the package manager required to work on
+the project.  It's required to be installed, however the `syndesis ui`
+command can be used for day to day development tasks. For example:
 
-## syndesis minishift
+```shell
+# install all the dependendencies and build the project
+$ syndesis ui --install --build
+```
 
-With `syndesis minishift` you can adequately manage a
-[minishift](https://www.openshift.org/minishift/) installation for
-hosting Syndesis. This command is especially useful for a simple and
+```
+$ syndesis ui --serve --minishift
+```
+
+Runs the app in development mode using minishift. Automates running
+`yarn watch:app:minishift` and restores the console URL when you stop
+the development server. API calls will be proxied to the provided URL
+pointed by the `BACKEND` environment variable.
+
+The proxy will require the session cookies to be able to properly work.
+The right cookies will be retrieved through an automated instance of
+Chromium, that will wait for the user to login. Once properly logged in
+- a condition recognized by the browser navigating back to the provided
+`BACKEND` URL - the session cookies will be extracted and the Chromium
+instance will be closed.
+
+It's also possibile to enable the _chaos mode_ setting the `CHAOS` env
+variable. In _chaos mode_ API requests have a 50% chance to fail with an
+error 500.   
+This mode is useful to test the resilience of the app.  
+
+**IMPORTANT**
+
+* the `BACKEND` URL should be the project URL as retrieved by
+  Minishift/Openshift console.
+* doublecheck that the URL doesn't end with a '/'.
+* never close the automated Chromium browser manually; if it stays open
+  probably after a successful login something went wrong and should be
+  debugged.
+
+To run the tests use the `--run-tests` switch:
+
+```shell
+$ syndesis ui --run-tests
+```
+
+To run the test suite for a specific package you can pass the package name:
+
+```shell
+$ yarn test --scope @syndesis/package-name
+```
+
+## syndesis crc
+
+With `syndesis crc` you can adequately manage a [CodeReady
+Containers](https://code-ready.github.io/crc/) installation for hosting
+Syndesis. This command is especially useful for a simple and
 self-contained development workflow.
 
-`syndesis minishift` requires that you have a current minishift in your
-path. You can download it directly from
-[GitHub](https://github.com/minishift/minishift/releases).
+When you're deciding between CodeReady Containers and Minishift for
+local OpenShift development environment take note that Minishift
+supports OpenShift up to 3.11, and CodeReady Containers supports
+OpenShift 4.x onward. CodeReady Containers also requires more resources
+to run.
 
-### Usage
+`syndesis crc` requires that you have a current crc binary in your path.
+You can download it directly from
+[https://cloud.redhat.com](https://cloud.redhat.com/openshift/install/crc/installer-provisioned).
 
-        --install                 Install to a running Minishift.
-        --app-options             Operator parameters when installing the app.
-                                  Use quotes and start with a space before appending the options (example: " --addons jaeger").
-    -p  --project                 Install into this project. Delete this project if it already exists.
-                                  By default, install into the current project (without deleting)
-        --profile <profile>       Use the given minishift profile
-        --reset                   Reset and initialize the minishift installation by
-                                  'minishift delete && minishift start'.
-        --full-reset              Full reset and initialie by
-                                  'minishift stop && rm -rf ~/.minishift/* && minishift start'
-        --operator-only           Only install the operator but no custom resource
-        --memory <mem>            How much memory to use when doing a reset. Default: 4912
-        --cpus <nr cpus>          How many CPUs to use when doing a reset. Default: 2
-        --disk-size <size>        How many disk space to use when doing a reset. Default: 20GB
-        --vm-driver <driver>      Which virtual machine driver to use (depends on OS)
-        --show-logs               Show minishift logs during startup
-        --openshift-version <ver> Set OpenShift version to use when reseting (default: v3.11.0)
-        --tag <tag>               Syndesis version/tag to install. If not given, then the latest
-                                  version from master is installed
-        --local                   Use the local resource files instead of fetching them from GitHub
-    -f  --force-binary-download   By default if the binary cli is present in the expected path, it will
-                                  be used. With this option enabled, the binary will be removed and downloaded,
-                                  ensuring it is the latest version
-    -o  --open                    Open Syndesis in the browser
-    -y  --yes                     Assume 'yes' automatically when asking for deleting
-                                  a given project.
-        --camel-k <version>       Install the Camel-K operator with version <version>
-                                  (version is optional)
-        --camel-k-options "opts"  Options used when installing the camel-k operator.
-                                  Use quotes and start with a space before appending the options.
-        --maven-mirror            Install Maven Mirror to be used with --maven-mirror when building.
-        --deploy-latest           Deploy latest tags from dockerhub.
-        --nodev                   Do not set the devSupport flag in CR (deploys all images)
-        --custom-resource         Provide a custom resource to be installed by the operator
-        --man                     Open HTML documentation in the Syndesis Developer Handbook
+`syndesis crc` will attempt to download the latest syndesis cli from the
+[syndesis release
+page](https://github.com/syndesisio/syndesis/releases/latest). If this
+fails, you can try downloading the right binary for your distribution
+and placing it under `tools/bin/commands/binaries`.
 
-### Installing Syndesis
+### Installing
 
 You can easily install Syndesis with the option `--install`. This option
 triggers the creation of all relevant OpenShift resources objects in the
@@ -463,27 +464,99 @@ namespace.
   <i class="fa warning"></i> Any existing project will be deleted first when specified with `--project`. This option is also an easy and quick way to recreate a Syndesis installation.
 </div>
 
+### Resetting CodeReady Containers
+
+The quickest way to get a fresh Syndesis setup is to use `--project`
+which will install Syndesis into a clean, new project.
+
+However, you can also recreate the whole CodeReady Containers
+installation with `--reset`. This will delete the CodeReady Containers
+VM (`crc delete`) and create a new one (`crc start`). It doesn't harm if
+the CodeReady Containers VM does not exist so that you can use `--reset`
+also on a fresh CodeReady Containers installation.
+
+If you want to get a real clean installation use `--full-reset` which
+deletes the `~/.crc` directory which holds downloaded artifacts like the
+ISO image for the CodeReady Containers VM. Using `--full-reset` forces
+CodeReady Containers to re-download all those files.
+
+There are several options which influence the re-creation of the VM:
+
+| Option                | Description                                                                                                      | Default |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------- | ------- |
+| `--memory`            | Memory to use for the CodeReady VM.                                                                              | 8 GB    |
+| `--cpus`              | Number of CPUs used for the CodeReady VM.                                                                        | 4       |
+| `--pull-secret-file`  | File holding the OCP4 pull secret                                                                                |         |
+| `--vm-driver`         | Which virtual machine driver to use. For OS X this can be 'virtualbox'                                           |         |
+| `--bundle`            | Path to system bundle (required when using virtualbox vm-driver)                                                 | 3.7.1   |
+
+### Example
+This short example performs the following actions:
+ - Stops and deletes a running CodeReady Containers VM (if existent)
+ - Removes `~/.crc` (if existent)
+ - Install Syndesis in OpenShift modes (S2I builds & image streams) in
+   project `syndesis`
+ - Opens Syndesis UI in the default browser
+
+```shell
+# Complete fresh installation in project "syndesis"
+$ syndesis crc --full-reset --install --project syndesis
+
+# Open Syndesis in default browser
+$ syndesis crc -o
+```
+
+## syndesis minishift
+
+With `syndesis minishift` you can adequately manage a
+[minishift](https://www.openshift.org/minishift/) installation for
+hosting Syndesis. This command is especially useful for a simple and
+self-contained development workflow.
+
+When you're deciding between CodeReady Containers and Minishift for
+local OpenShift development environment take note that Minishift
+supports OpenShift up to 3.11, and CodeReady Containers supports
+OpenShift 4.x onward. CodeReady Containers also requires more resources
+to run.
+
+`syndesis minishift` requires that you have a current minishift in your
+path. You can download it directly from
+[GitHub](https://github.com/minishift/minishift/releases).
+
+### Installing
+
+You can easily install Syndesis with the option `--install`. This option
+triggers the creation of all relevant OpenShift resources objects in the
+currently connected OpenShift project.
+
+<div class="alert alert-info admonition" role="alert"> <i class="fa
+warning"></i> Any existing project will be deleted first when specified
+with `--project`. This option is also an easy and quick way to recreate
+a Syndesis installation.  </div>
 
 ### Setting a maven repository manager
 
-To reduce build time, it is recommended to setup a local maven repository
-manager, you can use the `--maven-mirror` parameter when installing 
-minishift, this it will instal nexus on a nexus project.
+To reduce build time, it is recommended to setup a local maven
+repository manager, you can use the `--maven-mirror` parameter when
+installing minishift, this it will install
+[Nexus](https://www.sonatype.com/nexus-repository-oss) on the `nexus`
+OpenShift project.
 
 ### Use the latest syndesis-operator
 
-The `syndesis-operator` is an important part of syndesis, to update image
-streams, manage syndesis components in openshift and much more. The 
-`syndesis-operator` is placed in `$HOME/.syndesis/bin/syndesis-operator` and 
-then later installed in openshift. Use the `-f` parameter to download the 
-latest `syndesis-operator` release.
+The `syndesis-operator` is an important part of syndesis, to update
+image streams, manage syndesis components in openshift and much more.
+The `syndesis-operator` is placed in
+`$HOME/.syndesis/bin/syndesis-operator` and then later installed in
+openshift. Use the `-f` parameter to download the latest
+`syndesis-operator` release.
 
 ### Installing an addon
 
-There are some additional software packaged as `addon` such as: jaeger, 
+There are some additional software packaged as `addon` such as: jaeger,
 data virtualization, camel-k, knative, etc. You can install syndesis
-with these addons by using the `--app-options` parameter, for example, to 
-install syndesis with camel-k:
+with these addons by using the `--app-options` parameter, for example,
+to install syndesis with camel-k:
 
 ``` bash
 syndesis minishift --install --project syndesis --app-options " --addons camelk"
@@ -508,103 +581,49 @@ Minishift to re-download all those files.
 There are several options which influence the re-creation of the
 VM:
 
-| Option                | Description                                                                                                      | Default |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------- | ------- |
-| `--memory`            | Memory to use for the Minishift VM.                                                                              | 4 GB    |
-| `--cpus`              | Number of CPUs used for the Minishift VM.                                                                        | 2       |
-| `--disk-size`         | Disk space used for Minishift.                                                                                   | 20 GB   |
-| `--show-logs`         | Whether to show OpenShift logs during startup.                                                                   | false   |
+| Option                | Description                                                                                                       | Default |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------- | ------- |
+| `--memory`            | Memory to use for the Minishift VM.                                                                               | 4 GB    |
+| `--cpus`              | Number of CPUs used for the Minishift VM.                                                                         | 2       |
+| `--disk-size`         | Disk space used for Minishift.                                                                                    | 20 GB   |
+| `--show-logs`         | Whether to show OpenShift logs during startup.                                                                    | false   |
 | `--vm-driver`         | Which virtual machine driver to use. For OS X this can be 'virtualbox', 'xhyve' or 'vmwarefusion' (if installed). |         |
-| `--openshift-version` | OpenShift version to use                                                                                         | 3.7.1   |
+| `--openshift-version` | OpenShift version to use                                                                                          | 3.7.1   |
 
 ### Example
 
 This short example performs the following actions:
 
   - Stops and deletes a running Minishift VM (if existent)
-
   - Removes `~/.minishift` (if existent)
-
   - Install Syndesis in OpenShift modes (S2I builds & image streams) in
     project `syndesis`
-
   - Open Syndesis UI in the default browser
-  
-  - Install a nexus maven repository manager in project `nexus`
+  - Install a Nexus maven repository manager in project `nexus`
 
-<!-- end list -->
-
-    # Complete fresh installation in project "syndesis"
-    syndesis minishift --full-reset --install --project syndesis --maven-mirror
-    
-    # Open Syndesis in default browser
-    syndesis minishift -o
-
-
-## syndesis system-test
-
-The `system-test` command is for running a full blown system test of Syndesis by installing it in one of multiple projects which are managed in a pool.
-
-
-### Usage
-
+```shell
+# Complete fresh installation in project "syndesis"
+$ syndesis minishift --full-reset --install --project syndesis --maven-mirror
+# Open Syndesis in default browser
+$ syndesis minishift -o
 ```
-Usage: syndesis system-test [... options ...]
-
-Options for system-test:
-    --project <project>       The test project to use
-    --token <token>           Token for connecting to the server
-    --server <url>            OpenShift server url to use for the tests.
-                              If not given, use the currently connected server
-    --pool <project>          If no project is given, use a pooling mechanism.
-                              This pool has to be created before with --create-pool
-    --test-id <id>            Id to identify the test run
-    --create-pool <prefix>    Create project pool for system-tests with
-                              all projects with the given prefix
-    --list-pool               Show all locks for the pool
-    --release-project <t-id>  Release project for given test id (or all if no test id is given)
-```
-
-### How it works
-
-<div class="alert alert-info admonition" role="alert">
-  <i class="fa note"></i> This section needs a more detailed explanation how the systems tests are working in detail.
-</div>
-
-
 
 ## syndesis dev
 
 Dev commands are useful helpers for developing Syndesis
 
-### Usage
-
-    Usage: syndesis dev [... options ...]
-    
-    Options for dev:
-    --debug <name>            Setup a port forwarding to <name> pod (default: server)
-    --cookie                  Loads a local valid cookie to access Syndesis APIs when using Minishift
-    --cleanup                 Removes 'Completed' pods
-    --cleanup --nuke          Remove all Syndesis created OpenShift objects and remove all data from the database
-                              (both switches need to be specified)
-    --refresh                 Used in conjuction with --cookie, forces a refresh of the cookie.
-                              Ex: curl -k --cookie $(syndesis dev --cookie --refresh)  "https://$(oc get route syndesis  --template={{.spec.host}})/api/v1/connections"
-    --update-manifest <name>  Updates the json manifest for the given connector
-    --install-maven-mirror    Install Maven Nexus app as mirror to current cluster.
-    --version                 Show running version of cluster
-    --man                     Open HTML documentation in the Syndesis Developer Handbook
-
 ### Debug a syndesis component
 
-The `--debug` parameter enable port-forwarding of port 5005 from a specific pod (by
-default: "server") to port 5005 on the localhost. You then can point
-your Java IDE to port 5005 on localhost for connecting for remote
-debugging. As argument to `--debug` "server", "meta" and "atlasmap" can
-be used, which are our Java based services.
-For this to work the running pod must have been started with java debug agent enabled.
-You can enable it by setting the environment variabel JAVA_DEBUG=true to the 
-deployment config, for example, the following command will enable java debug agent 
-in the syndesis-server deployment config and the pod will be restarted.
+The `--debug` parameter enable port-forwarding of port 5005 from a
+specific pod (by default: "server") to port 5005 on the localhost. You
+then can point your Java IDE to port 5005 on localhost for connecting
+for remote debugging. As argument to `--debug` "server", "meta" and
+"atlasmap" can be used, which are our Java based services.  For this to
+work the running pod must have been started with java debug agent
+enabled.  You can enable it by setting the environment variabel
+JAVA_DEBUG=true to the deployment config, for example, the following
+command will enable java debug agent in the syndesis-server deployment
+config and the pod will be restarted.
 
 ``` bash
 oc set env dc/syndesis-server JAVA_DEBUG=true
@@ -612,67 +631,39 @@ oc set env dc/syndesis-server JAVA_DEBUG=true
 
 ### Prune old stuff
 
-As the syndesis components are updated or integrations installed, after days 
-or weeks many old syndesis components such as images, deployment configs, 
-builds are stored and consumes space, it may slow the system down. So, you
-can free space by pruning old stuff from openshift by using the `--cleanup`
-parameter.
+As the syndesis components are updated or integrations installed, after
+days or weeks many old syndesis components such as images, deployment
+configs, builds are stored and consumes space, it may slow the system
+down. So, you can free space by pruning old stuff from openshift by
+using the `--cleanup` parameter.
 
-## syndesis doc
+### Install Maven Nexus as mirror
 
-This command is used to generated and manage this documentation which
-you are currently reading.
+The Syndesis S2i builds are loading dependencies from Maven central
+respectively Red Hat repositories. In order to improve performance and
+save some bits in transfer we recommend to use a Maven Nexus as mirror.
+This will decrease the amount of bits loaded from the internet every
+time a Syndesis integration is created.
 
-### Usage
+You can add the Maven Nexus application in a separate project namespace
+to the OpenShift cluster by using:
 
-    Usage: syndesis doc [... options ...]
-    
-    Options for doc:
-    -d  --directory <dir>         Top-level dir holding doc source and output directory. Default: "doc/sdh"
-    -i  --input <file>            Input file to use. Default: "index.adoc"
-        --out <dir>               Directory to generate files (default: "output")
-        --html                    Generate HTML pages
-        --pdf <out>               Generate PDF and write it to <out> (default: "sdh.pdf")
-        --epub <out>              Generate Epub and write it to <out> (default: "sdh.epub")
-        --gh-pages <msg>          Create everything into the gh-pages branch and commit with <msg>
-    -o  --open                    Open HTML documentation in default browser after doc generation
-    -l  --local                   Use locally installed commands instead of Docker image
+```shell
+$ syndesis dev --install-maven-mirror
+```
 
-`syndesis doc` uses by default a Docker container to create the
-documentation. Therefore a Docker daemon must be accessible, and it must
-allow [bind volume
-mounts](https://docs.docker.com/engine/admin/volumes/bind-mounts/) to
-the local `doc/sdh` directory. Bind mounts are possible for Linux Docker
-daemons and for "Docker for Mac". But it is not the case for the
-Minishift exposed Docker daemon, as this daemon is running isolated in a
-VM.
+This will create a new project on the cluster `nexus` and will install
+the latest Nexus Maven repository manager. You can use this Nexus
+instance when building and pushing new images to the Syndesis image
+streams using S2i.
 
-You can always run `asciidoctor` locally with the `--local` (short:
-`-l`) options. See the [Asciidoctor
-manual](https://asciidoctor.org/#installation) for more information how
-to install Asciidoctor.
+```shell
+$ syndesis -m s2i -i --maven-mirror http://nexus-nexus.apps-crc.testing/nexus/content/groups/public
+```
 
-### Output
-
-Input and output has the same defaults but can be changed with the
-following
-options
-
-|                  |             |                                                                                          |
-| ---------------- | ----------- | ---------------------------------------------------------------------------------------- |
-| `--input <file>` | `-i <file>` | Input document in Asciidoc format which is by default `$SYNDESIS_DIR/doc/sdh/index.adoc` |
-| `--output <dir>` | `-o <dir>`  | Output directory, default is `$SYNDESIS_DIR/doc/sdh/output`                              |
-
-By default `syndesis doc` creates the documentation in HTML format, but
-more formats are
-supported:
-
-|                 |                                                                                                                                                                                    |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--html`        | Create HTML documentation in the output directory                                                                                                                                  |
-| `--pdf <name>`  | Create PDF documentation. `<name>` is optional, but when given, then this specifies the file name generated in the output directory. By default `sdh.pdf` is used.                 |
-| `--epub <name>` | Create the documentation in Epub format. `<name>` is optional, but when given, then this specifies the file name generated in the output directory. By default `sdh.epub` is used. |
-
+This will build a new base S2i image and use the Maven Nexus as mirror
+so all previously loaded dependencies will be loaded from the local
+Nexus instance instead of loading from the internet.
 
 ## syndesis release
 
@@ -680,10 +671,8 @@ Use `syndesis release` for performing a release of Syndesis. A Syndesis
 release consists of:
 
   - Maven artifacts of the backend and runtime services
-
   - Docker images pushed to Docker Hub
-
-  - A set of OpenShift templates referencing these images
+  - Manifests created for operatorhub.io
 
 This chapter describes how you can efficiently perform a release and how
 to troubleshoot if something goes wrong. This documentation might also
@@ -691,42 +680,11 @@ be interesting to you even when you do not perform a release on your
 own, as it might help you to understand how the various Syndesis
 artifacts fit together.
 
-### Usage
-
-    Perform a release
-    
-    This command performs a release but does no automated rollback when something fails.
-    Please refer to the manual at https://docs.syndesis.io for more details and what needs
-    to be cleaned up in case of a failure.
-    
-    Usage: syndesis release [... options ...]
-    
-    Options for release:
-    -n  --dry-run                 Dry run, which performs the whole build but does no tagging,
-                                  artifact upload or pushing Docker images
-        --release-version <ver>   Version to release (e.g. "1.2.1"). This is a mandatory argument.
-        --snapshot-release        Snapshot release which can be created on a daily basis.
-                                  A timestamped version will be created automatically, and no Maven artifacts
-                                  are pushed to maven central. No moving tag will be moved, too.
-        --dev-version <version>   Next development version. If not given, set to
-                                  "<major>.<minor>-SNAPSHOT" as calculated from
-                                  --release-version (e.g. "1.2-SNAPSHOT")
-        --settings <file>         Path to a custom settings.xml to use for the release.
-                                  This file must contain all the credentials to be used for Sonatype.
-                                  By default ~/.m2/settings.xml is used.
-        --local-maven-repo <dir>  Local dir for holding the local Maven repo cache.
-                                  If not given, then a new
-                                  temporary directory will be used
-                                  (and removed after the release)
-        --docker-user <user>      Docker user for Docker Hub
-        --docker-password <pwd>   Docker password for Docker Hub
-        --no-git-push             Don't push the release tag (and symbolic major.minor tag)
-        --git-remote              Name of the git remote to push to. If not given, its trying to be pushed
-                                  to the git remote to which the currently checked out branch is attached to.
-                                  Works only when on a branch, not when checked out directly.
-    
-        --log <log-file>          Write full log to <log-file>, only print progress to screen
-        --man                     Open HTML documentation in the Syndesis Developer Handbook
+Even though the documenation mentions how to do this manually, we
+usually perform an automated release on our [CI
+server](https://ci.fabric8.io/view/syndesis/). The CI server is set up
+with the necessary credentials and anyone with the permissions to run
+the release jobs can run a release.
 
 A lot of output is produced during a release. If you are only interested
 to see the major steps only, then you can use `--log` to redirect the
@@ -748,15 +706,11 @@ look like:
 ```
 
   1. Always run `syndesis` from the repo and branch you want to release.
-
   2. The release version is mandatory and must be in the format
     `<major>.<minor>.<patch>`.
-
   3. Use a clean local Maven repository to avoid side effects
-
   4. Redirect the full output to `/tmp/build.log` but still print the
     main steps to the console.
-
   5. Make only a dry run, without pushing any artifacts out nor checking
     in any changed files.
 
@@ -771,11 +725,9 @@ release artifacts are uploaded:
     and your account needs to have write access to the
     [syndesis](https://hub.docker.com/u/syndesis/) Docker Hub
     organisation.
-
   - You have `gpg` to have installed and set up a gpg-agent for being
     able to sign Maven artifacts during deployment in a non-interactive
     mode.
-
   - You need to have access to the "syndesis" account on
     ([oss.sonatype.org](https://oss.sonatype.org/) for being able to
     publish Maven artifacts. This credential needs to be added to either
@@ -788,31 +740,31 @@ repository, which can be either checkout from a branch like `1.2.x` for
 a patch release or directly from `master`. It is highly recommended to
 run the release directly from a freshly checked out directory:
 
-``` bash
+```shell
 # Go to a temporary directory
-cd /tmp
+$ cd /tmp
 
 # Clone repository afresh, but only use the last history entry (--depth=1)
-git clone --depth=1 https://github.com/syndesisio/syndesis.git
+$ git clone --depth=1 https://github.com/syndesisio/syndesis.git
 
 # Jump into the directory
-cd syndesis
+$ cd syndesis
 
 # Switch to the target branch if needed (or stay on master)
-git fetch --depth 1 origin 1.2.x:1.2.x
-git checkout 1.2.x
+$ git fetch --depth 1 origin 1.2.x:1.2.x
+$ git checkout 1.2.x
 
 # Call Syndesis from the checked out clone
-./tools/bin/syndesis release --release-version 1.2.8 .....
+$ ./tools/bin/syndesis release --release-version 1.2.8 .....
 
 # Push to origin after a successful release.
 # This automatically done if --no-git-push is given
-git push 1.2.8
-git push -f 1.2
+$ git push 1.2.8
+$ git push -f 1.2
 
 # Remove the temporary clone again
-cd ..
-rm -rf syndesis
+$ cd ..
+$ rm -rf syndesis
 ```
 
 Please note that you should always call `syndesis` out of the branch for
@@ -829,7 +781,6 @@ two groups:
   - **Build steps** are performed to build the release and create the
     artifacts. Also during the build Maven artifacts are uploaded to the
     staging area for publishing to Maven central
-
   - **Persist steps** are then used for releasing objects, pushing
     Docker images to Docker Hub, committing and tagging in Git (but only
     when the build steps have been performed successfully).
@@ -839,29 +790,20 @@ two groups:
   - Check whether the current local Git clone is *clean*, i.e. that is
     does not have any modified files. The script will abort if this is
     the case.
-
   - Update the versions of all `pom.xml` files below `app/` to the
     version given with `--release-version`. If no `--release-version` is
     given, then the script aborts.
-
   - Run an `mvn clean install` to verify that the build is not broken
     and all tests succeed.
-
-  - Re-generate the OpenShift templates in `install` so that the image
-    streams included in these templates refer to Docker images with the
-    new version.
-
-  - Now run an `mvn -Prelease clean deploy` to deploy all artifacts to a
+  - Run an `mvn -Prelease clean deploy` to deploy all artifacts to a
     new staging repository on oss.sonatype.org, the platform for release
     artifacts on Maven central. The staging repository on this Sonatype
     Nexus is validated and closed.
-
   - If `--docker-user` and `--docker-password` is given, then a `docker
     login` is performed. Otherwise, it is assumed that the user is
     already logged in.
-
   - The Docker images are created with `mvn -Prelease,image package` in
-    the `server`, `meta`, `ui` and `s2i` modules.
+    the `server`, `meta`, `ui` `operator`, and `s2i` modules.
 
 If the option `--dry-run` (short: `-n`) is provided, the script drops
 the staging repository at Sonatype and stops. You should examine the
@@ -885,13 +827,10 @@ and also *deleted* after the release run.
     `1.2.8`, then the minor version is `1.2`. If this minor version tag
     already exists on Docker Hub, its moved to the newly created
     version.
-
   - The staging repository on Sonatype is released. It will take a bit,
     but the artifact should then be downloadable from [Maven
     central](https://search.maven.org/) soon after.
-
   - Commit all modified local files to the local Git repo.
-
   - Create a Git tag for the release version (e.g. `git tag 1.2.8`).
 
 The next steps are for creating templates for the minor version:
@@ -899,9 +838,7 @@ The next steps are for creating templates for the minor version:
   - In `install` create new templates which contain image streams that
     reference images with the minor version (e.g.
     `syndesis/syndesis-server:1.3` for a release version of 1.3.8).
-
   - Commit those generated templates
-
   - Tag it with the minor version (e.g. `1.2`), overwriting an already
     existing minor version tag
 
@@ -915,12 +852,11 @@ Finally, the tags just created on the local Git repo is pushed to the
 remote repository. You can omit this with the option `--no-git-push`. If
 to so, the last step can also be performed manually afterwards with:
 
-``` bash
-git push 1.2.8   
-git push -f 1.2   1
+```shell
+$ git push 1.2.8   
+$ git push -f 1.2   1
 ```
-
-  1. Using `-f` as the minor tag needs to be moved.
+**NOTE**: The usage of `-f` flag as the minor tag needs to be moved.
 
 Please be careful to **not** push the master branch upstream (i.e. do
 **not** a plain `git push`). We only want to have the tag with all the
@@ -948,7 +884,6 @@ variants, there exist two OpenShift templates variants:
     template will keep your application at precisely this patch-level.
     You would have to update your templates and recreate your
     applications if you want to upgrade.
-
   - The other set of templates references images only via its minor
     version, e.g. `syndesis/syndesis-ui:1.2`. Using these templates has
     the advantage that application created from these templates
@@ -981,20 +916,18 @@ In detail, a snapshot release differs from a normal release as it:
 
   - …​ doesn’t release artifacts on Maven central, but pushes Docker
     images and creates a Git tag for referencing the proper templates.
-
   - …​ skips all checks and tests when building to maximise the
     likelihood that the release succeeds. The rationale here is to
     better have untested daily snapshot release than no snapshot release
     because of test failure (which in many cases are not because of
     errors, but of failure in the infrastructure)
-
   - …​ force pushes the snapshot tag on GitHub so that multiple releases
     per day are allowed
 
-**Example**
+### Example
 
-``` bash
-syndesis release \
+```shell
+$ syndesis release \
      --snapshot-release \                   1
      --local-maven-repo /tmp/clean-repo \   2
      --git-remote origin \                  3
@@ -1003,11 +936,8 @@ syndesis release \
 ```
 
   1. Enable snapshot release with a version in the format 1.3.5-20180419
-
   2. Point to an empty repository to avoid side effects when building
-
   3. Push to the origin repository
-
   4. Docker credentials required for pushing to Docker Hub
 
 A daily Jenkins job with this configuration run on
@@ -1023,7 +953,6 @@ breaks early, you only need to clean up locally. If the process fails
 before the step *=== Pushing Docker images* you only need to:
 
   - Reset your local git repo with `git reset --hard`
-
   - Potentially remove the create staging repository on
     `http://oss.sonatype.org/` (but it doesn’t harm if it is not cleaned
     up immediately).
@@ -1033,12 +962,9 @@ wrong. But these things should take care of if this should be the case:
 
   - Remove Docker Hub tags for the pushed images, which is best done on
     the Docker Hub Web UI
-
   - Revert your local git commits to the point before the release. If
     you did this on a fresh checked out repo (as recommended), you just
     could delete the whole clone.
-
-
 
 ## syndesis install
 
@@ -1046,42 +972,7 @@ With `syndesis install` you can install Syndesis to an arbitrary
 OpenShift cluster. If you want to install to
 [Minishift](https://www.openshift.org/minishift/) the [syndesis
 minishift](#syndesis-minishift) command is recommended as it supports
-some additional features specific to
-    Minishift.
-
-### Usage
-
-    -s  --setup               Install CRDs clusterwide. Use --grant if you want a specific user to be
-                              able to install Syndesis. You have to run this option once as
-                              cluster admin.
-    -u  --grant <user>        Add permissions for the given user so that user can install
-                              the operator in her projects. Must be run as cluster admin.
-        --cluster             Add the permission for all projects in the cluster
-                              (only when used together with --grant)
-    -p  --project             Install into this project. Delete this project
-                              if it already exists. By default, install into the current project
-                              (without deleting)
-        --operator-only       Only install the operator but no resource
-        --route               Route to use. If not given, the route is trying to be detected
-                              from the currently connected cluster.
-        --console             The URL to the OpenShift console
-        --tag <tag>           Syndesis version/tag to install. If not given, then the latest
-                              version from master is installed
-        --dev                 Prepare for development of Syndesis so that S2I builds of
-                              Syndesis images are picked up properly (implies --watch)
-        --force               Override an existing "Syndesis" if present
-    -w  --watch               Wait until cluster is up
-        --local               install from local Git repo when using. By default the
-                              resource descriptor is downloaded from GitHub remotely.
-    -o  --open                Open Syndesis in browser when installation is ready (implies --watch)
-    -y  --yes                 Assume 'yes' automatically when asking for deleting
-                              a given project.
-        --memory-server <mem> Memory limit to set for syndesis-server. Specify as "800Mi"
-        --memory-meta <mem>   Memory limit to set for syndesis-meta. Specify as "512Mi"
-        --test-support        Allow test support endpoint for syndesis-server
-    
-    You have to run --setup --grant <user> as a cluster-admin before you can
-    install Fuse Online as a user.
+some additional features specific to Minishift.
 
 The deployment happens to the currently connected OpenShift cluster. So
 it’s mandatory that you have logged into the cluster with `oc login`
@@ -1091,7 +982,6 @@ The installation process consists of two steps:
 
   - An initial setup which has to be performed as *cluster admin* which
     is a one-off action which needs to be done only once.
-
   - Installation of Syndesis into a specific project by the *app admin*,
     a regular user of OpenShiftm which can be performed as many times as
     required.
@@ -1108,10 +998,11 @@ own, then you have to grant specific permissions to her.
 To perform this setup step, which needs to be performed only once per
 cluster, you have to run `syndesis` **while being connected as a cluster
 admin**. For `minishift` use `oc login -u system:admin` if you have the
-`admin-user` addon enabled.
+`admin-user` addon enabled, for crc follow the login instructions you
+got when starting up crc.
 
-``` bash
-syndesis install --setup
+```shell
+$ syndesis install --setup
 ```
 
 This will install only the CRD. In addition to grant a user *developer*
@@ -1119,7 +1010,7 @@ the proper permission to create a `Syndesis` resource, you should add
 `--grant <user>`:
 
 ``` bash
-syndesis install --setup --grant <user>
+$ syndesis install --setup --grant <user>
 ```
 
 This call adds permissions to read and write `Syndesis` resource objects
@@ -1135,33 +1026,33 @@ lost.
 After the CRDs a registered, you can easily install Syndesis directly
 with
 
-``` bash
-syndesis install
+```shell
+$ syndesis install
 ```
 
 Depending on whether you have granted the current user access this step
 has to be done either as admin or as a regular user.
 
-**Example for Minishift**
+### Example for Minishift
 
-``` bash
+```shell
 # Enable the admin user on Minishift
-minishift addons enable admin-user
+$ minishift addons enable admin-user
 
 # Create a minishift instance
-minishift start --memory 4192
+$ minishift start --memory 4192
 
 # Switch to admin
-oc login -u system:admin
+$ oc login -u system:admin
 
 # Register CRD and grant permissions to "developer"
-syndesis install --setup --grant developer --cluster
+$ syndesis install --setup --grant developer --cluster
 
 # Switch to account developer
-oc login -u developer
+$ oc login -u developer
 
 # Install Syndesis
-syndesis install
+$ syndesis install
 ```
 
 A route name can be given with `--route`. This step can be omitted as
@@ -1175,8 +1066,7 @@ project `proj186023`. However, you don’t have to provide the route name.
 
 If you want to have a link to the OpenShift console to read the Pod
 logs, you have to add the `--console` option with the full URL to the
-console. Unfortunately, this cannot be autodetected. If not given, no
-link appears.
+console. If not given, no link appears.
 
 By default, this commands installs Syndesis in the currently connected
 project, but you can specify an alternative project with `--project
@@ -1186,9 +1076,10 @@ option. By default, you are asked whether you want to delete the project
 for recreation. You can switch off the security question with the option
 `--yes` (short: `-y`).
 
-<div class="alert alert-info admonition" role="alert">
-  <i class="fa warning"></i> Don’t use `syndesis install --project $(oc project -q) --yes`. You’ll shoot yourself into the foot. Ask the author if you want to know more details.
-</div>
+<div class="alert alert-info admonition" role="alert"> <i class="fa
+warning"></i> Don’t use `syndesis install --project $(oc project -q)
+--yes`. You’ll shoot yourself into the foot. Ask the author if you want
+to know more details.  </div>
 
 If you want to wait until everything is running (including fetching of
 the Docker images), you can specify `--watch` (short: `-w`) which blocks
@@ -1199,11 +1090,12 @@ installation with `--open` (short: `-o`)
 
 ### Development Mode
 
-As with [syndesis minishift](#syndesis-minishift) you can also use this
-command to set up a development platform for Syndesis. *Development
-platform* here means that you can create Docker images on your own with
-[syndesis build](#syndesis-build) and can use them with an automatic
-redeployment after the build.
+As with [syndesis crc](#syndesis-crc) or [syndesis
+minishift](#syndesis-minishift) you can also use this command to set up
+a development platform for Syndesis. *Development platform* here means
+that you can create Docker images on your own with [syndesis
+build](#syndesis-build) and can use them with an automatic redeployment
+after the build.
 
 You can switch on this mode with the option `--dev`. When the operator
 has deployed the application, the application imagestreams refer to
@@ -1219,10 +1111,10 @@ With the option `--tag` you can select a specific version of Syndesis to
 install. By default, the currently checked out checked out branch is
 used.
 
-**Example**
+### Example
 
-``` bash
-syndesis install --route syndesis.192.168.64.12.nip.io --tag 1.4
+```shell
+$ syndesis install --route syndesis.192.168.64.12.nip.io --tag 1.4
 ```
 
 This example installs the latest Syndesis version of the 1.4 branch to
@@ -1233,31 +1125,3 @@ You can see a list of available tags with `git tag`. Tags prefixed with
 do not contain images streams themselves but refer to the image streams
 installed on this cluster.
 
-### Quick Installation
-
-<div class="alert alert-info admonition" role="alert">
-  <i class="fa warning"></i> The following scripts are not yet updated and probably don’t work as expected. Please stay tuned.
-</div>
-
-If you only want to install Syndesis without developing for, there is even an easier without checking out Syndesis into a local Git repository.
-
-You can directly use the standalone installation script [syndesis-install](https://raw.githubusercontent.com/syndesisio/syndesis/master/tools/bin/install-syndesis)
-for installing Syndesis. Just download this [script](https://raw.githubusercontent.com/syndesisio/syndesis/master/tools/bin/install-syndesis),
-save it as "syndesis-install" and then call it with
-
-``` bash
-bash install-syndesis --route $(oc project -q).6a63.fuse-ignite.openshiftapps.com --open
-```
-
-Or, if you feel fancy (and trust us), then you can directly install the
-latest version of Syndesis by deleting and recreating the current
-project with a single line:
-
-``` bash
-bash <(curl -sL https://bit.ly/syndesis-install) -p $(oc project -q) -r $(oc project -q).6a63.fuse-ignite.openshiftapps.com -o
-```
-
-All you need is to have `bash`, `curl` and `oc` installed and you need
-to be connected to an OpenShift cluster.
-
-Use `install-syndesis --help` for a list of options (which is a subset of `syndesis install` described above).

--- a/content/docs/development.md
+++ b/content/docs/development.md
@@ -16,8 +16,7 @@ weight: 20
 Syndesis uses [Maven](http://maven.apache.org/) as build tool. Maven
 groups are used to separate the various Syndesis parts.
 
-In details Syndesis consists of the following
-groups:
+In details Syndesis consists of the following groups:
 
 | Group           | Maven                     | Docker Image               | Description                                                     |
 | --------------- | ------------------------- | -------------------------- | --------------------------------------------------------------- |
@@ -33,7 +32,6 @@ groups:
 
 ![Figure 1. Group dependencies](/images/syndesis-group-dependencies.png)
 
-
 _Figure 1. Group dependencies_
 
 ### Naming Conventions
@@ -41,54 +39,52 @@ _Figure 1. Group dependencies_
 The following conventions are used for naming directories, modules and
 Java packages.
 
-<div class="alert alert-info admonition" role="alert">
-  <i class="fa important"></i> These conventions are mandatory and should be also checked for when doing pull request reviews.
-</div>
+<div class="alert alert-info admonition" role="alert"> <i class="fa
+important"></i> These conventions are mandatory and should be also
+checked for when doing pull request reviews.  </div>
 
   - Each directory directly below `app/` is specific for a certain Maven
     group. E.g. the directory `app/extension` is reserved for all Maven
     modules belonging to the Maven group `io.syndesis.extension`. The
     directory name is reflected as the last name part.
-
   - All names (groups, modules, package) are using the **singular**
     form. E.g. its a `io.syndesis.connector`, *not*
     `io.syndesis.connectors`.
-
   - Each Maven module is prefixed with the last part of the group name.
     E.g. the directory `app/integration/api` holds a Maven module for
     the the Maven group `io.syndesis.integration`, and the module’s
     artefactId is `integration-api`.
-
   - A module’s directory name is directly reflected as the last part of
     the Maven module name. If the Maven module name consists of multiple
     parts (e.g. artifact `integration-project-generator`), then the
     corresponding directory is also a concatenated word (like in
     `integration/project-generator`). Multipart names should be the
     exception, though.
-
   - There should be only one level deep modules, so each Maven group
     directory holds all Maven modules flat.
-
   - Each module has a **single** top-level package, reflecting the Maven
     module name. E.g. for the Maven module `common-util` in group
     `io.syndesis.common` has a single top-level package
     `io.syndesis.common.util` This top-level package should reflect the
     artefact name, with dashes replaced by dots.
 
-
-
-<div class="alert alert-info admonition" role="alert">
-  <i class="fa note"></i> Not every module has been already transformed to this scheme. This will happen step-by-step. But for new groups and modules this scheme has to be followed.
-</div>
+<div class="alert alert-info admonition" role="alert"> <i class="fa
+note"></i> Not every module has been already transformed to this scheme.
+This will happen step-by-step. But for new groups and modules this
+scheme has to be followed.  </div>
 
 ## Issue Labels
 
-We use [GitHub labels](https://github.com/syndesisio/syndesis/labels) to categorize epics, issues and tasks. They are the
-foundation of our process, so please use labels for issues.
+We use [GitHub labels](https://github.com/syndesisio/syndesis/labels) to
+categorize epics, issues and tasks. They are the foundation of our
+process, so please use labels for issues.
 
-<div class="alert alert-info admonition" role="alert">
-  <i class="fa caution"></i> Labels are living entities. This document describes the current status and might be slightly outdated. Please send a PR to adopt this section if the label structure changes. Also feel free to discuss the label structure anytime. It’s essential that labels describe our process, not that we have to adapt our process for these labels.
-</div>
+<div class="alert alert-info admonition" role="alert"> <i class="fa
+caution"></i> Labels are living entities. This document describes the
+current status and might be slightly outdated. Please send a PR to adopt
+this section if the label structure changes. Also feel free to discuss
+the label structure anytime. It’s essential that labels describe our
+process, not that we have to adapt our process for these labels.  </div>
 
 Labels are grouped. Each label consists of two parts: A **Group** and a
 **Name** which are separated by a slash (`/`). For example, the label
@@ -96,19 +92,18 @@ Labels are grouped. Each label consists of two parts: A **Group** and a
 module.
 
 The following label groups are available. There must be only at most one
-label from the "Exclusive"
-groups.
+label from the "Exclusive" groups.
 
 | Group       | Description                                                                                                                        | Excl. |
 | ----------- | ---------------------------------------------------------------------------------------------------------------------------------- | ----- |
 | **cat/**    | Misc categories which can be added freely                                                                                          |       |
-| **prio/**   | Priority of the issue. Only one `prio/` label must be added per issue. `prio/p0` is of highest priority, `prio/p2` the lowest one. | ✔︎    |
+| **prio/**   | Priority of the issue. Only one `prio/` label must be added per issue. `prio/p0` is of highest priority, `prio/p2` the lowest one. | ✔︎     |
 | **ext/**    | Reference to external projects                                                                                                     |       |
 | **source/** | Where did the issue originate from (stakeholders)? i.e. `source/qe` indicates that QE raised this issue.                           |       |
 | **group/**  | Internal Syndesis modules                                                                                                          |       |
 | **notif/**  | Notification label which can be added and removed to ping certain subteams                                                         |       |
 | **pr/**     | Labels which are only relevant for pull request and which have also some semantics for the bot managing pull requests              |       |
-| **size/**   | Tee shirt size for issues. Sizing is a subjective assessment and should be done relative to other issues.                          | ✔︎    |
+| **size/**   | Tee shirt size for issues. Sizing is a subjective assessment and should be done relative to other issues.                          | ✔︎     |
 | **status/** | Status of an issue or PR.                                                                                                          |       |
 
 Each label group serves a particular purpose, and for each issue and PR,
@@ -128,8 +123,7 @@ than such label as they touch more than one group (otherwise it wouldn’t
 be an epic).
 
 For Java code, a "group" roughly corresponds to a directory directly
-below
-`app/`
+below `app/`.
 
 | Group                 | Description                                                     |
 | --------------------- | --------------------------------------------------------------- |
@@ -173,8 +167,7 @@ meaning for the [pure-bot](https://github.com/syndesisio/pure-bot) bot
 which watches a pull request and performs certain action. These actions
 also involve monitoring and creating labels.
 
-The following labels are
-involved:
+The following labels are involved:
 
 | Notification            | Description                                                                                                                                                                                                                                                                                                                                                                                       |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -188,8 +181,7 @@ involved:
 
 Notification labels from the `notif/` group serve a particular purpose.
 They are used when one team wants to notify another group that a
-specific issue might have them relevance to
-them.
+specific issue might have them relevance to them.
 
 | Notification     | Description                                                                                                                                                                                                                      |
 | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -222,8 +214,7 @@ should be applied to help in triaging and prioritizing.
 ## External references
 
 This label group should be used if an external system is referenced,
-which is not part of the Syndesis mono
-repo.
+which is not part of the Syndesis mono repo.
 
 | External Project | Description                                                                                           |
 | ---------------- | ----------------------------------------------------------------------------------------------------- |
@@ -239,13 +230,82 @@ labels should be converted to `module/` kind of labels.
 
 Status labels are unique since they may trigger some automatic actions.
 
-The current status labels
-are:
+The current status labels are:
 
 | Status             | Description                                                                                                                                  |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | **status/blocked** | The current issue is blocked by another issue. Refer to the issue itself to see what is blocking this issued. This label is purely informal. |
 
+## Issue Management and Communication
+
+With Github as the primary tool for logging and handling issues, it is
+important to become proficient in utilising its interface and taking
+advantage of the extra tools available.
+
+### Displaying Issues
+
+Issues can be displayed natively in Github by clicking the
+[Issues](https://github.com/syndesisio/syndesis/issues) button at the
+top of the [main repository
+page](https://github.com/syndesisio/syndesis). This provides a list of
+all the issues which can be filtered according to text, status etc.
+
+Have a look at [how to find information in a
+repostiory](https://help.github.com/en/github/managing-your-work-on-github/finding-information-in-a-repository)
+on GitHub help. For example to show only issues that one is assigned to,
+the filter `is:issue is:open assignee:@me` can be used.
+
+Correspondingly, for pull requests pull requests awaiting ones review
+can be found using `is:pr is:open review-requested:@me ` filter.
+
+### Being Notified of Issues
+
+Once assigned to the project, the registered email address should being
+receiving notifications from Github concerning any modifications to any
+issues. This can quickly fill an inbox so filtering these into their own
+folder is recommended (a new developer can expect to see 50-100 per
+day). Additional tools, like Octobox or the new GitHub Notifications
+(currently in beta), are available for helping with managing these
+notifications so please ask other project members if you are struggling
+to handle them.
+
+### Administering Issues
+
+Issues are the bedrock of the project and provide the window into
+understanding what each developer is currently working on. Therefore, it
+is important to log issues, assign issues and provide comments to
+issues. Github provides tools to connect issues and Pull Requests (PRs)
+and even if the PR does not require an issue (rarely!) then it should be
+possible to provide sufficient context in the PR that spells out its
+nature and relevance.
+
+Once assigned, an issue is your's to log as much detail as required to
+portray any problems, difficulties or solutions. Should you need help
+then Github provides syntax using the _@UserName_ syntax to prompt
+other's to comment on the issue. Given the plethora of notifications
+that developers receive on a daily basis, it is recommended to use this
+syntax if you require additional input, since this sends additional
+notifications specifically asking the developer concerned to comment. In
+the event that you are unsure who to contact then it is not impolite to
+include a number of _@UserNames_ in the issue and someone will respond
+and either reply directly or in turn notify a person who can. Everyone
+understands the importance of collaboration so speaking up is to be only
+encouraged.
+
+### Closing Issues
+
+Development is about solving the issues and closing them down.
+Therefore, closing issues is a good thing. Do not be afraid to close an
+issue if the problem has been solved or indeed if the problem has gone
+away on its own (yes this does happen!). In the event. that a code
+change has occurred and a PR submitted then that PR will have been
+reviewed by another developer. There may be a back-and-forth in comments
+and requests for changes but finally the PR will be approved by the
+reviewer. Once that happens, the PR will be automatically merged and
+closed. If an issue is directly linked to the PR then that too will be
+closed as well. Should this not be required then the issue can of course
+be re-opened. Once the issue is closed then it is back to the dashboard
+to find a new one!
 
 ## Local Development
 
@@ -255,7 +315,6 @@ both the UI and REST API, this is how you’d do it.
 **Tips**
 
   - Build on branch, not master.
-
   - Callback URL Example:
     <https://syndesis.192.168.64.29.nip.io/api/v1/credentials/callback>
 
@@ -268,19 +327,15 @@ Some environment-specific instructions may be available below as well.
 1.  Make sure you have installed [node](https://nodejs.org/en/download/)
     version \>= 6.x.x and [Yarn](https://yarnpkg.com/en/docs/install)
     version \>= 0.18.1.
-
 2.  Get a developer deployment of Syndesis running in a Minishift
     environment as described in the [Syndesis
     Quickstart](https://syndesis.io/quickstart/). Most are specific to
     your environment, so follow the sections below for a quick setup.
     The general instructions are:
-    
+
       - Install a hypervisor for Minishift.
-    
       - Install Minishift.
-    
       - Install the OpenShift CLI.
-    
       - Make sure it’s in your `$PATH`
 
 **macOS**
@@ -289,22 +344,21 @@ If you’ll be using the Homebrew method, you’ll obviously need to have
 Homebrew installed. Then, to install the hypervisor for Minishift and
 Minishift itself:
 
-    $ brew install docker-machine-driver-xhyve
-    $ brew cask install minishift
+```shell
+$ brew install docker-machine-driver-xhyve
+$ brew cask install minishift
+```
 
 Finally, to install the OpenShift CLI, we recommend using Homebrew:
 `brew install openshift-cli`
 
 **Linux & Windows**
 
-  - [Install a hypervisor for
-    Minishift](https://docs.openshift.org/latest/minishift/getting-started/installing.html#install-prerequisites).
+  - [Install a hypervisor for Minishift](https://docs.openshift.org/latest/minishift/getting-started/installing.html#install-prerequisites).
     For macOS, we recommend using the Docker xhyve plugin
     [here](https://docs.openshift.org/latest/minishift/getting-started/setting-up-driver-plugin.html#xhyve-driver-install),
     which can be installed using Homebrew.
-
-  - [Install
-    Minishift](https://docs.openshift.org/latest/minishift/getting-started/installing.html#installing-instructions).
+  - [Install Minishift](https://docs.openshift.org/latest/minishift/getting-started/installing.html#installing-instructions).
     For macOS, we recommend you use the Homebrew method.
 
 Please note that you need to have the `oc` binary available in your
@@ -316,18 +370,70 @@ Please note that you need to have the `oc` binary available in your
 The goal here is to download the project to your laptop/PC, and to
 install Minishift, the VM that contains OpenShift.
 
-    $ git pull https://github.com/syndesisio/syndesis.git # or own fork
-    $ cd syndesis
-    
-    # install minishift
-    $ syndesis minishift --full-reset --project syndesis --maven-mirror 
-    
-    # install syndesis with jaeger addon
-    $ syndesis minishift --install --project syndesis --nodev --app-options " --addons jaeger"
+```shell
+$ git pull https://github.com/syndesisio/syndesis.git # or own fork
+$ cd syndesis
 
-<div class="alert alert-info admonition" role="alert">
-  <i class="fa important"></i> The jaeger is installed to support the activity log backed by jaeger opentracing, which is faster than the activity log stored in postgresql.
-</div>
+# install minishift
+$ syndesis minishift --full-reset --project syndesis --maven-mirror
+```
+
+You can also include other options when setting up, for example
+including an addon:
+
+```shell
+# install syndesis with jaeger addon
+$ syndesis minishift --install --project syndesis --nodev --app-options " --addons jaeger"
+```
+<div class="alert alert-info admonition" role="alert"> <i class="fa
+important"></i> The jaeger is installed to support the activity log
+backed by jaeger opentracing, which is faster than the activity log
+stored in postgresql.  </div>
+
+### Running without Kubernetes/OpenShift
+
+For some development tasks you can run Syndesis without running on a
+Kubernetes/OpenShift cluster. You won't be able to publish integrations,
+see activities or gather metrics, or any other functionality that
+requires a running cluster. This is best suited for quick turnaround
+development of backend APIs together with UI features. You'll need three
+components running the Syndesis backend, the PostgreSQL database it uses
+and the UI.
+
+Start by running a PostgreSQL database in a Docker container:
+
+```shell
+$ docker run -d --rm -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password -e POSTGRES_DB=syndesis postgres
+```
+<div class="alert alert-info admonition" role="alert"> <i class="fa
+important"></i> the `--rm` option will remove the container once done
+and all the stored data in the database with it, if you wish to keep the
+data omit that option </div>
+
+Next run the Syndesis backend, this step requires that you have
+downloaded all the dependencies and built the backend:
+
+```shell
+$ syndesis build -f -c --backend # to download dependencies and build the backend
+$ (cd app && ./mvnw -f server/runtime spring-boot:run)
+```
+
+The backend is started once you see a line containing this in the
+output:
+
+```
+Started Application in 28.9 seconds (JVM running for 29.615)
+```
+
+After that UI can be started by running (in two separate terminal
+sessions):
+
+```
+$ (cd app/ui-react && watch:packages)
+$ (cd app/ui-react && BACKEND=http://localhost:8080 yarn watch:app:proxy)
+```
+
+You can now access a running instance at <https://localhost:3000>.
 
 ### Day-to-Day
 
@@ -339,34 +445,44 @@ Simply skip to the
 
 **Get the Latest Changes**
 
-    $ git checkout master
-    $ git pull upstream master
-    $ git checkout <branch>
-    $ git rebase master
+```shell
+$ git checkout master
+$ git pull upstream master
+$ git checkout <branch>
+$ git rebase master
+```
 
 **Start of the Day** Make sure Minishift is running.
 
-    $ minishift status
+```shell
+$ minishift status
+```
 
 Which should look like:
 
-    Minishift:  Running
-    Profile:    minishift
-    OpenShift:  Running (openshift v3.6.0+c4dd4cf)
-    DiskUsage:  11% of 17.9G
+```
+Minishift:  Running
+Profile:    minishift
+OpenShift:  Running (openshift v3.6.0+c4dd4cf)
+DiskUsage:  11% of 17.9G
+```
 
 If it isn’t, start it with:
 
-    $ minishift start
+```shell
+$ minishift start
+```
 
 **Login into and Set up OpenShift**
 
 This step is required regardless of whether it’s a first-time install or
 not. It logs you in and points OpenShift to use Minishift resources.
 
-    $ oc login -u developer
-    $ eval $(minishift oc-env)
-    $ eval $(minishift docker-env)
+```shell
+$ oc login -u developer
+$ eval $(minishift oc-env)
+$ eval $(minishift docker-env)
+```
 
 The eval’s set a number of environment variables, like change the
 `$PATH` and `$DOCKER_HOST`, so each time you do a Syndesis build it’s
@@ -374,16 +490,21 @@ good to make sure those are invoked.
 
 **End of the Day**
 
-    $ minishift stop
+```shell
+$ minishift stop
+```
 
 **Start the UI App & Open in the Browser**
 
-    $ yarn start:minishift
-    $ open https://$(oc get routes syndesis --template "{{.spec.host}}")
+```shell
+$ yarn start:minishift
+$ open https://$(oc get routes syndesis --template "{{.spec.host}}")
+```
 
 **Prune resources**
 
-You can free some disk space by removing and pruning obsolete resources from openshift.
+You can free some disk space by removing and pruning obsolete resources
+from openshift.
 
     $ syndesis dev --cleanup
     
@@ -397,10 +518,12 @@ it seems to work without that though.
 It would clean the database if we increase the schema version, if we
 don’t it remains the same.
 
-    $ syndesis build -m rest -f -i docker -k
+```
+$ syndesis build -m rest -f -i docker -k
+```
 
 Alternatively, you can use the REST API Endpoint:
-/api/v1/test-support/reset-db
+`/api/v1/test-support/reset-db`
 
 **Connecting to the Database**
 
@@ -410,7 +533,9 @@ connect to the database using a tool like
 the DB pod’s name either from `oc get pods` or from the OpenShift
 console. Then use the following command:
 
-    $ oc port-forward <db pod name> 5432:5432
+```shell
+$ oc port-forward <db pod name> 5432:5432
+```
 
 Now start pgadmin and add a new DB server, use `localhost` for the
 `host` setting. For the username and password look on the DB pod’s
@@ -421,7 +546,6 @@ In pgadmin you can see the table by navigating into the tree under
 public > Tables > jsondb`. Right click, and then go to `View Data > View
 All Rows`.
 
-
 ## UI
 
 After you’ve set up your initial Local Development environment, you’re
@@ -431,14 +555,18 @@ ready to contribute to the UI.
 
 From the project root directory:
 
-    $ cd app/ui
-    $ yarn install
+```shell
+$ cd app/ui
+$ yarn install
+```
 
 ### Start up the App
 
 **Using Minishift resources (recommended):**
 
-    $ yarn start:minishift
+```shell
+$ yarn start:minishift
+```
 
 The `yarn start:minishift` command works when it can properly detect
 your local development machine’s IP address. A proxy server inside the
@@ -452,17 +580,17 @@ start:minishift` command.
 
 Open the Syndesis UI in your browser from the command line by running:
 
-``` bash
+```shell
 # on macOS
 $ open https://$(oc get routes syndesis --template "{{.spec.host}}")
 ```
 
-``` bash
+```shell
 # on linux
 $ xdg-open https://$(oc get routes syndesis --template "{{.spec.host}}")
 ```
 
-``` bash
+```shell
 # on windows
 $ start https://$(oc get routes syndesis --template "{{.spec.host}}")
 ```
@@ -479,42 +607,26 @@ Minishift. Don’t be surprised if most things don’t load and there isn’t
 any data in the UI. Only use this if you’re totally blocked and need to
 work on something minor/aesthetic in the UI.
 
-    $ yarn start
+```shell
+$ yarn start
+```
 
 ### Running Tests
 
 To run tests or lint there are two more commands you can run in separate
 terminals.
 
-    $ yarn test
+```shell
+$ yarn test
+```
 
 ### Running Linter
 
 If you don’t, the CI will, and your PR build will likely fail.
 
-    $ yarn lint
-
-You should be able to access the UI in your browser at
-<http://localhost:4200>
-
-### Code Documentation
-
-We use [Compodoc](https://compodoc.github.io/website/) for
-documentation, or
-[here](https://compodoc.github.io/website/guides/comments.html) to see
-how to format comments. Files get generated automatically in the
-`/documentation` directory. Read the documentation
-\[here\](<https://compodoc.github.io/website/guides/getting-started.html>)
-to see how to properly document features. You can automatically generate
-and run docs using Yarn:
-
-``` bash
-$ yarn compodoc
+```shell
+$ yarn lint
 ```
-
-Or manually with `compodoc -s`, or `compodoc` if you want it to simply
-generate the files in the default `/documentation` directory and run it
-with an HTTP server.
 
 ### Technology Stack
 
@@ -522,30 +634,19 @@ Included in this stack are the following technologies:
 
   - Language: [TypeScript](http://www.typescriptlang.org) (JavaScript
     with @Types)
-
-  - Framework: [Angular](https://angular.io/)
-
-  - Testing: [Cucumber.js](https://cucumber.io/) (BDD Unit Test
-    Framework), [Karma](https://karma-runner.github.io/1.0/index.html)
+  - Framework: [React](https://reactjs.org/)
+  - Testing: [Jest](https://jestjs.io/) and [Karma](https://karma-runner.github.io/1.0/index.html)
     (Unit Test Runner),
-    [Istanbul](https://github.com/gotwarlost/istanbul) (Code Coverage)
-
   - Linting: [TsLint](https://github.com/palantir/tslint) (Linting for
     TypeScript)
-
-  - Logging: WIP
-
   - Code Analysis: [Codelyzer](https://github.com/mgechev/codelyzer)
     (TsLint rules for static code analysis of Angular TypeScript
     projects) / WIP
-
-
 
 ## REST API
 
 After you’ve set up your initial Local Development environment, you’re
 ready to contribute to the REST API.
-
 
 ## Troubleshooting
 
@@ -555,8 +656,10 @@ the browser console or the terminal to see if it’s a dependency issue.
 
 ### UI Dependency Issues
 
-    $ rm -rf node_modules
-    $ yarn install
+```shell
+$ rm -rf node_modules
+$ yarn install
+```
 
 ### VM Trouble
 
@@ -574,37 +677,46 @@ before you get a running VM, which is what `--full-reset` does. So as a
 rule of thumb, you can have a terminal with those evals and keep it open
 and do all of the Syndesis building from there.
 
-    $ syndesis minishift --full-reset --install -p syndesis -i docker
+```shell
+$ syndesis minishift --full-reset --install -p syndesis -i docker
+```
 
 **syndesis command not found** If you get `'syndesis' command not found`
 then use the full path to the `syndesis` binary instead. This assumes
-you are in the root of the project
-    directory.
+you are in the root of the project directory.
 
-    $ ./tools/bin/syndesis minishift --full-reset --install -p syndesis -i docker
+```shell
+$ ./tools/bin/syndesis minishift --full-reset --install -p syndesis -i docker
+```
 
 **If OpenShift templates have been updated** This should not be the
 first choice, since it changes the IP of the VM, and in general should
 not be necessary for just building and updating the version.
 
-    $ syndesis minishift --full-reset --install
+```shell
+$ syndesis minishift --full-reset --install
+```
 
 **VM Trouble**
 
-    $ syndesis build
-    
-**Pods self updating**. Ocasionally you can notice some syndesis pods may have been updated, it occurs
-because the image streams are pointing to dockerhub and whenever there is an update of that image on
-dockerhub, then your local pod will be updated. To prevent theses updates, set the DEV_SUPPORT=true 
-environment variable on syndesis-operator deployment config.
+```shell
+$ syndesis build
+```
 
-    $ oc set env dc/syndesis-operator DEV_SUPPORT=true
-    
+**Pods self updating**. Occasionally you can notice some syndesis pods
+may have been updated, it occurs because the image streams are pointing
+to dockerhub and whenever there is an update of that image on dockerhub,
+then your local pod will be updated. To prevent theses updates, set the
+`DEV_SUPPORT=true` environment variable on syndesis-operator deployment
+config.
+
+```shell
+$ oc set env dc/syndesis-operator DEV_SUPPORT=true
+```
 
 Other things you can try: - `rm -rf ~/.minishift` - Check the OpenShift
 console and look for logs. - Is it a xip or nip problem?
 <http://downoruprightnow.com/status/nip.io>
-
 
 ### Diagnostics
 
@@ -612,33 +724,42 @@ console and look for logs. - Is it a xip or nip problem?
 
 When a problem occur, the first thing should be to examine the logs.
 
-    # syndesis-server pod
-    $ oc logs -f `oc get -o name pod -l syndesis.io/component=syndesis-server`
-    
-    # twilog integration
-    $ oc logs -f `oc get -o name pod -l syndesis.io/type=integration -l syndesis.io/integration=i-twilog`
-    
-    # postgresql log
-    $ oc logs -f `oc get -o name pod -l syndesis.io/component=syndesis-db` -c postgresql
+```shell
+# syndesis-server pod
+$ oc logs -f `oc get -o name pod -l syndesis.io/component=syndesis-server`
 
-You can examine the pod initialization events and many other details about the pod.
+# log of an integration named "twilog"
+$ oc logs -f `oc get -o name pod -l syndesis.io/type=integration -l syndesis.io/integration=i-twilog`
 
-    $ oc describe `oc get -o name pod -l syndesis.io/component=syndesis-server`
+# postgresql log
+$ oc logs -f `oc get -o name pod -l syndesis.io/component=syndesis-db` -c postgresql
+```
+
+You can examine the pod initialization events and many other details
+about the pod.
+
+```shell
+$ oc describe `oc get -o name pod -l syndesis.io/component=syndesis-server`
+```
 
 **Enable the java debug agent on a pod**
-    
-    # to enable debug on an integration of name twilog
-    $ oc set env `oc get dc -o name|grep twilog` JAVA_DEBUG=true
-    
-    # to enable debug on syndesis-server
-    $ oc set env dc/syndesis-server JAVA_DEBUG=true
 
-**Connect to postgresql database** You can use `psql` tool to connect to the postgresql database.
+```
+# to enable debug on an integration named "twilog"
+$ oc set env `oc get dc -o name|grep twilog` JAVA_DEBUG=true
 
-    $ oc port-forward `oc get -o name pod -l syndesis.io/component=syndesis-db` 5432:5432
-    $ psql -U syndesis -h localhost syndesis
+# to enable debug on syndesis-server
+$ oc set env dc/syndesis-server JAVA_DEBUG=true
+```
 
+**Connect to postgresql database** You can use `psql` tool to connect to
+the postgresql database.
+
+```
+$ oc port-forward `oc get -o name pod -l syndesis.io/component=syndesis-db` 5432:5432
+$ psql -U syndesis -h localhost syndesis
+```
 
 ### Still Having Trouble?
 
-Ask on IRC \#syndesis
+Ask on [Gitter](https://gitter.im/syndesisio/community)


### PR DESCRIPTION
This brings over updates made separately in the Syndesis Developer
Handbook in the main Syndesis repository, updates the documents to
replace outdated information and reformats the docs a bit.

I think the docs still are not 100% up to date, at least this would help
in removing the need for parallel documentation in the Syndesis
Developer Handbook and the confusion about where to edit the docs and
where to point users/contributors for documentation.