### PR TITLE
refactor: flexible layout and TOC styling

### DIFF
--- a/themes/syndesis/scss/_sidenav.scss
+++ b/themes/syndesis/scss/_sidenav.scss
@@ -38,8 +38,7 @@ $menu-title-height: 30px;
   }
 
   @include media-breakpoint-down(md) {
-    flex: none;
-    width: 214px;
+    flex: 0 0 214px;
     position: absolute;
     margin-left: -214px;
     z-index: 10000;

--- a/themes/syndesis/scss/_toc.scss
+++ b/themes/syndesis/scss/_toc.scss
@@ -8,13 +8,15 @@
 
 .toc {
   @include media-breakpoint-up(lg) {
-    flex: 0 0 314px;
+    flex: 0 0 auto;
   }
 }
 
 #TableOfContents{
-  background-color: rgba(0, 0, 0, 0.1);
-  padding: 10px 20px 10px 20px;
+  padding: 10px 20px 10px 10px;
+  border-image: linear-gradient(#9adde8, #0088ce) 0 0 0 100%;
+  border-left: 5px solid;
+  margin-left: 20px;
 
   ul {
     list-style: none;
@@ -23,6 +25,7 @@
 
     li {
       display: block;
+      line-height: 1.6rem;
     }
   }
 
@@ -33,6 +36,6 @@
   }
 
   &>ul>li>ul>li>a {
-    font-style: italic;
+    font-style: bold;
   }
 }

--- a/themes/syndesis/scss/syndesis.scss
+++ b/themes/syndesis/scss/syndesis.scss
@@ -44,11 +44,8 @@ body {
   .main-content {
     padding-left: 15px;
     padding-right: 15px;
-    width: 100%;
-
-    @include media-breakpoint-up(lg) {
-      width: calc(100% - 214px - 314px);
-    }
+    min-width: 0; // https://weblog.west-wind.com/posts/2016/feb/15/flexbox-containers-pre-tags-and-managing-overflow
+    flex: 1;
 
     h2 {
       font-size: 1.75rem;


### PR DESCRIPTION
This makes sure that the TOC takes up as much space as it needs to to
prevent word wrap (as much as possible), making the TOC a bit
unreadable by tweaking the flex layout to have fixed 214px sidenav,
growable TOC and main content taking up remaining space.

For TOC styling this removes the gray background, use of italic for
headings; and increases the line height to make the menu more legible.
Also adds a gradient as a separator from the content.