### PR TITLE
re #168 add icons for connectors + extensions

### DIFF
--- a/content/docs/architecture/_index.md
+++ b/content/docs/architecture/_index.md
@@ -4,5 +4,5 @@ draft: false
 title: "Architecture"
 weight: 20
 collapsible: true
-pre: "<i class='fas fa-cubes'></i>"
+pre: "<i class='fas fa-cubes fa-fw'></i>"
 ---

--- a/content/docs/cli/_index.md
+++ b/content/docs/cli/_index.md
@@ -4,5 +4,5 @@ draft: false
 title: "CLI"
 weight: 30
 collapsible: true
-pre: "<i class='fas fa-keyboard'></i>"
+pre: "<i class='fas fa-keyboard fa-fw'></i>"
 ---

--- a/content/docs/connectors/_index.md
+++ b/content/docs/connectors/_index.md
@@ -4,5 +4,5 @@ draft: false
 title: "Connectors"
 weight: 40
 collapsible: true
-pre: "<i class='fas fa-window-restore'></i>"
+pre: "<i class='fas fa-plug'></i>"
 ---

--- a/content/docs/connectors/_index.md
+++ b/content/docs/connectors/_index.md
@@ -4,5 +4,5 @@ draft: false
 title: "Connectors"
 weight: 40
 collapsible: true
-pre: "<i class='fas fa-plug'></i>"
+pre: "<i class='fas fa-plug fa-fw'></i>"
 ---

--- a/content/docs/contributing/_index.md
+++ b/content/docs/contributing/_index.md
@@ -4,5 +4,5 @@ draft: false
 title: "Contributing"
 weight: 50
 collapsible: true
-pre: "<i class='fas fa-user-friends'></i>"
+pre: "<i class='fas fa-user-friends fa-fw'></i>"
 ---

--- a/content/docs/extensions/_index.md
+++ b/content/docs/extensions/_index.md
@@ -4,14 +4,15 @@ draft: false
 title: "Extensions"
 weight: 40
 collapsible: true
-pre: "<i class='fas fa-network-wired'></i>"
+pre: "<i class='fas fa-network-wired fa-fw'></i>"
 ---
 
 Syndesis is a platform designed to provide maximum flexibility to your integrations. Most of the time you will be fine using the connectors and other tools provided, but, in a certain situation you may feel you need something specific to your business goal. For that situation we've thought to provide a special mechanism called `Extension`.
 
-An extension is a dedicate development that will enhance the functionality of your platform and integration runtime by adding any custom behavior you need. You can import that special behavior on your Syndesis installation. 
+An extension is a dedicated development that will enhance the functionality of your platform and integration runtime
+ by adding any custom behavior you need. You can import that special behavior on your Syndesis installation. 
 
-We provide three way to add extensions:
+We provide three ways to add extensions:
 
 - Connector
 - Step

--- a/content/docs/extensions/_index.md
+++ b/content/docs/extensions/_index.md
@@ -4,7 +4,7 @@ draft: false
 title: "Extensions"
 weight: 40
 collapsible: true
-pre: "<i class='fas fa-window-restore'></i>"
+pre: "<i class='fas fa-network-wired'></i>"
 ---
 
 Syndesis is a platform designed to provide maximum flexibility to your integrations. Most of the time you will be fine using the connectors and other tools provided, but, in a certain situation you may feel you need something specific to your business goal. For that situation we've thought to provide a special mechanism called `Extension`.

--- a/themes/syndesis/layouts/partials/docs/sidenav.html
+++ b/themes/syndesis/layouts/partials/docs/sidenav.html
@@ -11,13 +11,13 @@
     {{ end }}
 
     <!-- Static Items -->
-    <li class="fa-li">
+    <li>
       <a href="https://github.com/syndesisio/syndesis/issues/" target="blank">
         <i class='fas fa-life-ring fa-fw'></i>&nbsp;<span>Issues & Help</span>
       </a>
     </li>
     {{ $File := .File }} {{with $File.Path }}
-    <li class="fa-li">
+    <li>
       <a href="https://github.com/syndesisio/syndesis.io/edit/master/content/{{ $File.Dir }}{{ $File.LogicalName }}" target="blank">
         <i class='fas fa-edit fa-fw'></i>&nbsp;Edit this Page
       </a>

--- a/themes/syndesis/layouts/partials/docs/sidenav.html
+++ b/themes/syndesis/layouts/partials/docs/sidenav.html
@@ -11,15 +11,15 @@
     {{ end }}
 
     <!-- Static Items -->
-    <li>
+    <li class="fa-li">
       <a href="https://github.com/syndesisio/syndesis/issues/" target="blank">
-        <i class='fas fa-life-ring'></i>&nbsp;<span>Issues & Help</span>
+        <i class='fas fa-life-ring fa-fw'></i>&nbsp;<span>Issues & Help</span>
       </a>
     </li>
     {{ $File := .File }} {{with $File.Path }}
-    <li>
+    <li class="fa-li">
       <a href="https://github.com/syndesisio/syndesis.io/edit/master/content/{{ $File.Dir }}{{ $File.LogicalName }}" target="blank">
-        <i class='fas fa-edit'></i>&nbsp;Edit this Page
+        <i class='fas fa-edit fa-fw'></i>&nbsp;Edit this Page
       </a>
     </li>
     {{ end }}

--- a/themes/syndesis/layouts/partials/sidenav.html
+++ b/themes/syndesis/layouts/partials/sidenav.html
@@ -52,7 +52,7 @@
   {{end}}
   <li>
     <a href="https://github.com/syndesisio/syndesis/issues/" target="blank">
-      <i class='fas fa-life-ring'></i>&nbsp;
+      <i class='fas fa-life-ring fa-fw'></i>&nbsp;
     <span>Issues & Help</span>
     </a>
   </li>
@@ -61,7 +61,7 @@
   {{ $File := .File }} {{with $File.Path }}
     <li>
       <a href="https://github.com/syndesisio/syndesis.io/edit/master/content/{{ $File.Dir }}{{ $File.LogicalName }}" target="blank">
-        <i class='fas fa-edit'></i>&nbsp;Edit this Page
+        <i class='fas fa-edit fa-fw'></i>&nbsp;Edit this Page
       </a>
     </li>
     {{end}}

--- a/themes/syndesis/scss/_sidenav.scss
+++ b/themes/syndesis/scss/_sidenav.scss
@@ -135,7 +135,6 @@ SIDEBAR MENU
       }
 
       &--collapse {
-        //border-bottom: 1px solid #D7D7D7;
         cursor: pointer;
         display: flex;
         margin: 0.25rem 0;
@@ -166,7 +165,7 @@ SIDEBAR MENU
         i {
           font-size: 18px !important;
           margin-top: 0.25em;
-          padding-right: 6px !important;
+          margin-right: 0.50em;
         }
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,7 +7,7 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@fortawesome/fontawesome-free@^5.13.0":
+"@fortawesome/fontawesome-free@5.13.0":
   version "5.13.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.13.0.tgz#fcb113d1aca4b471b709e8c9c168674fbd6e06d9"
   integrity sha512-xKOeQEl5O47GPZYIMToj6uuA2syyFlq9EMSl2ui0uytjY9xbe8XS0pexNWmxrdcCyNGyDmLyYw5FtKsalBUeOg==
@@ -4583,7 +4583,7 @@ postcss-place@^4.0.1:
     postcss "^7.0.2"
     postcss-values-parser "^2.0.0"
 
-postcss-preset-env@^6.7.0:
+postcss-preset-env@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/postcss-preset-env/-/postcss-preset-env-6.7.0.tgz#c34ddacf8f902383b35ad1e030f178f4cdf118a5"
   integrity sha512-eU4/K5xzSFwUFJ8hTdTQzo2RBLbDVt83QZrAvI07TULOkmyQlnYlpwep+2yIK+K+0KlZO4BvFcleOCCcUtwchg==


### PR DESCRIPTION
cc @squakez  cc @oscerd 

Team, let me know what you think.. I really have no idea what looks good or makes the most sense. The big darker ones look better than thinner icons with more details.

<img width="598" alt="Screenshot 2020-04-24 15 27 42-02" src="https://user-images.githubusercontent.com/3844502/80223973-f5515b00-8640-11ea-87c8-6f3e87eabaf5.png">

(minus the big red arrows 😂 )

if you don't like it, look at these and let me know what you prefer:
https://fontawesome.com/icons?d=gallery&m=free

fix #168 