### PR TITLE
fix(cloudflare): use bearer token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,10 +51,9 @@ jobs:
 
             ./publish-to-gh-pages.sh
 
-            if [[ -n "${CLOUDFLARE_API_KEY}" && -n "${CLOUDFLARE_EMAIL}" && -n "${CLOUDFLARE_ZONE_ID}" ]]; then
-              curl -X DELETE "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
-                -H "X-Auth-Email: ${CLOUDFLARE_EMAIL}" \
-                -H "X-Auth-Key: ${CLOUDFLARE_API_KEY}" \
+            if [[ -n "${CLOUDFLARE_API_KEY}" && -n "${CLOUDFLARE_ZONE_ID}" ]]; then
+              curl -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
+                -H "Authorization: Bearer ${CLOUDFLARE_API_KEY}" \
                 -H "Content-Type: application/json" \
                 --data '{"purge_everything":true}'
             fi


### PR DESCRIPTION
The current setup leads to authentication error when accessing Cloudflare API:

```
{"success":false,"errors":[{"code":10000,"message":"Authentication error"}]}
```

We need to use the bearer token (this is what is generated on the account page), and `POST` method for this API, `DELETE` might work, but it's not documented that way.