### PR TITLE
fix: copy and style images

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -152,6 +152,7 @@ function manual_render(cb) {
       cb(new Error(text));
     }
   }
+  src('build/documentation/images/**/*.png').pipe(dest('documentation/manual'));
 
   cb();
 }

--- a/themes/syndesis/scss/syndesis.scss
+++ b/themes/syndesis/scss/syndesis.scss
@@ -78,6 +78,7 @@ body {
 
 .article {
   padding: 2rem 2rem 21rem 2rem;
+  max-width: 80rem;
 
   table.tableblock {
     border: 1px solid $pf-black-300;
@@ -109,5 +110,10 @@ body {
   .admonitionblock .title {
     background-color: $pf-light-blue-100;
     padding: 1rem;
+  }
+
+  .image img {
+    max-width: 100%;
+    height: auto;
   }
 }


### PR DESCRIPTION
Images should appear now, also narrows the text to 80rem for legibility.