### PR TITLE
refactor: TOC for in-page content on the right

### DIFF
--- a/themes/syndesis/scss/_asciidoc.scss
+++ b/themes/syndesis/scss/_asciidoc.scss
@@ -1,5 +1,4 @@
 .page.book {
-  padding-left: 21rem;
 
   .article {
     margin: auto;
@@ -68,6 +67,10 @@
     }
   }
 
+  #content {
+    margin-right: 20rem;
+  }
+
   #footer-text {
     color: $gray;
     font-size: .8rem;
@@ -75,28 +78,28 @@
   }
 
   #toc {
-    background-color: #eee;
-    color: $pf-black-500;
-    height: 100vh;
-    left: 0;
-    padding: 7rem 0 0 1rem;
-    position: fixed;
-    top: 0;
+    border-image: linear-gradient(#9adde8, $pf-blue-400) 0 0 0 100%;
+    border-left: 5px solid;
+    color: $pf-blue-400;
+    padding: 10px 20px 0 30px;
+    position: absolute;
+    right: 0;
+    top: 6.5rem;
     width: 20rem;
 
     ul {
       list-style: none;
-      max-height: 86vh; // 100 - 7 (#toc padding-top)
+      margin-bottom: 0;
       overflow: auto;
       padding-left: 0;
 
       li {
-        padding: .3rem 0;
+        line-height: 1.6rem;
       }
     }
 
     a {
-      color: $pf-black-500;
+      color: $pf-blue-400;
     }
   }
 

--- a/themes/syndesis/scss/_footer.scss
+++ b/themes/syndesis/scss/_footer.scss
@@ -9,10 +9,10 @@
   bottom: 0;
   color: $pf-white;
   height: 20rem;
-  margin-top: 8em;
-  padding-top: 2rem;
+  margin-top: 2em;
   padding-bottom: 2rem;
-  position: absolute;
+  padding-top: 2rem;
+  position: relative;
   width: 100%;
 
   .row {
@@ -26,8 +26,6 @@
 
   .btn-primary {
     @include button-variant($pf-white, $pf-red-200, $pf-black);
-    font-weight: bold;
-    width: 40%;
 
     @include media-breakpoint-down(lg) {
       width: 70%;
@@ -40,6 +38,9 @@
     @include media-breakpoint-down(xs) {
       width: 70%;
     }
+
+    font-weight: bold;
+    width: 40%;
   }
 
   .rh-logo {


### PR DESCRIPTION
Places the TOC for Asciidoc content on the right, as it is done for the
markdown content.