### PR TITLE
fix: add scroll-margin-top for headings

### DIFF
--- a/themes/syndesis/scss/_docs.scss
+++ b/themes/syndesis/scss/_docs.scss
@@ -12,6 +12,14 @@
 
 .docs {
   .docBody {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5 {
+      scroll-margin-top: 5rem;
+    }
+
     h2 {
       font-size: 1.75rem;
       padding: 35px 0 10px;


### PR DESCRIPTION
When targeting the header via fragment, it's position is below the top
navigation, this adds a margin on the top to move the scroll position
so it's visible below the header.