### PR TITLE
fix(css): make .toc shirinkable/growable

### DIFF
--- a/themes/syndesis/scss/_toc.scss
+++ b/themes/syndesis/scss/_toc.scss
@@ -8,7 +8,7 @@
 
 .toc {
   @include media-breakpoint-up(lg) {
-    flex: 0 0 auto;
+    flex: 1;
   }
 }
 


### PR DESCRIPTION
To help with the responsive layout this sets `flex: 1` instead of
`flex: 0 0 auto`, so the `.toc` is shirnkable/growable rather than
taking up as much space as it would like and thus encroaching on the
main content. Another alternative could be to set the `max-width` to
prevent the `.toc` from taking up too much space. With `flex: 1` browser
decides how to split the width between `#sidebar`, `.main-content` and
`.toc`, whereas with `max-width` we could set the maximum width the
`.toc` would take up.
I ended up deciding to go with `flex: 1`, because I could not decide
what `max-width` would be best.

Fixes #203